### PR TITLE
Ensure docker container builds correctly

### DIFF
--- a/parachain/docker-compose.yml
+++ b/parachain/docker-compose.yml
@@ -2,16 +2,16 @@ version: "3.2"
 
 services:
   dev:
-    container_name: node-template
+    container_name: artemis-node
     image: paritytech/ci-linux:production
-    working_dir: /var/www/node-template
+    working_dir: /var/www/artemis-node
     ports:
       - "9944:9944"
     environment:
-      - CARGO_HOME=/var/www/node-template/.cargo
+      - CARGO_HOME=/var/www/artemis-node/.cargo
     volumes:
-      - .:/var/www/node-template
+      - .:/var/www/artemis-node
       - type: bind
         source: ./.local
         target: /root/.local
-    command: bash -c "cargo build --release && ./target/release/node-template --dev --ws-external"
+    command: bash -c "cargo build --release && ./target/release/artemis-node --dev --ws-external"

--- a/parachain/scripts/docker_run.sh
+++ b/parachain/scripts/docker_run.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-echo "*** Start Substrate node template ***"
+echo "*** Start Artemis Node ***"
 
 cd $(dirname ${BASH_SOURCE[0]})/..
 


### PR DESCRIPTION
It was previously referencing substrate-node-template artifacts. But we renamed our node to `artemis-node` and this broke the container.