### PR TITLE
Fix linting errors in parachain

### DIFF
--- a/parachain/.rustfmt.toml
+++ b/parachain/.rustfmt.toml
@@ -1,2 +1,0 @@
-tab_spaces = 4
-hard_tabs = true

--- a/parachain/pallets/dummy-verifier/src/lib.rs
+++ b/parachain/pallets/dummy-verifier/src/lib.rs
@@ -4,7 +4,7 @@
 use frame_support::{decl_module, decl_storage, decl_event, decl_error,
 	dispatch::{DispatchResult, Dispatchable}};
 use frame_support::{Parameter, traits::schedule::Anon as ScheduleAnon};
-use frame_system::{self as system, ensure_signed, ensure_root};
+use frame_system::{self as system};
 
 use sp_std::prelude::*;
 

--- a/parachain/pallets/polkaeth-app/src/lib.rs
+++ b/parachain/pallets/polkaeth-app/src/lib.rs
@@ -19,8 +19,6 @@ use frame_system::{self as system, ensure_signed};
 pub type PolkaETH<T> =
 	<<T as Trait>::Currency as Currency<<T as system::Trait>::AccountId>>::Balance;
 
-use sp_std::prelude::*;
-
 use common::{AppID, Application, Message};
 
 pub trait Trait: system::Trait {


### PR DESCRIPTION
And remove `.rustfmt.toml` since I'm no longer using that. It chokes on substrate macros.