### PR TITLE
Remove obsolete bridge code

### DIFF
--- a/parachain/Cargo.lock
+++ b/parachain/Cargo.lock
@@ -3538,6 +3538,7 @@ dependencies = [
  "common",
  "frame-support",
  "frame-system",
+ "pallet-balances",
  "parity-scale-codec",
  "serde",
  "sp-core",

--- a/parachain/common/src/lib.rs
+++ b/parachain/common/src/lib.rs
@@ -14,7 +14,8 @@ pub use types::{AppID, Message};
 /// The bridge module implements this trait
 pub trait Bridge {
 
-    fn deposit_event(app_id: AppID, name: Vec<u8>, data: Vec<u8>);
+    // just a dummy stand-in until we flesh out this trait some more
+    fn dummy();
 
 }
 

--- a/parachain/pallets/bridge/src/lib.rs
+++ b/parachain/pallets/bridge/src/lib.rs
@@ -29,7 +29,6 @@ decl_event!(
 		Hash = <T as frame_system::Trait>::Hash,
 	{
 		MessageReceived(AccountId, AppID, Hash),
-		AppEvent(AppID, Vec<u8>, Vec<u8>),
 	}
 );
 
@@ -60,7 +59,7 @@ decl_module! {
 
 impl<T: Trait> Bridge for Module<T> {
 
-	fn deposit_event(app_id: AppID, name: Vec<u8>, data: Vec<u8>) {
-		Self::deposit_event(RawEvent::AppEvent(app_id, name, data));
+	fn dummy() {
+		()
 	}
 }

--- a/parachain/pallets/polkaeth-app/Cargo.toml
+++ b/parachain/pallets/polkaeth-app/Cargo.toml
@@ -59,6 +59,13 @@ features = ["derive"]
 default-features = false
 path = "../../common"
 
+[dependencies.balances]
+default-features = false
+git = 'https://github.com/paritytech/substrate.git'
+package = 'pallet-balances'
+tag = 'v2.0.0-rc4'
+version = '2.0.0-rc4'
+
 [features]
 default = ['std']
 std = [
@@ -66,6 +73,7 @@ std = [
     'codec/std',
     'frame-support/std',
     'frame-system/std',
+    'balances/std',
     'sp-core/std',
     'sp-std/std',
     'sp-io/std',

--- a/parachain/pallets/polkaeth-app/src/lib.rs
+++ b/parachain/pallets/polkaeth-app/src/lib.rs
@@ -1,27 +1,25 @@
 #![allow(unused_variables)]
 #![cfg_attr(not(feature = "std"), no_std)]
 ///
-/// Skeleton implementation for a PolkaETH token
+/// Implementation for a PolkaETH token
 ///
-/// Resources:
-///   https://blog.polymath.network/substrate-deep-dive-imbalances-8dfa89cc1d1
-///
+use frame_system::{self as system, ensure_signed};
 use frame_support::{
 	decl_error, decl_event, decl_module, decl_storage,
 	dispatch::DispatchResult,
 	traits::{Currency, ExistenceRequirement, WithdrawReason, WithdrawReasons},
 };
-
 use sp_std::prelude::*;
+use common::{AppID, Application, Message};
 
-use frame_system::{self as system, ensure_signed};
+#[cfg(test)]
+mod mock;
+
+#[cfg(test)]
+mod tests;
 
 pub type PolkaETH<T> =
 	<<T as Trait>::Currency as Currency<<T as system::Trait>::AccountId>>::Balance;
-
-use sp_std::prelude::*;
-
-use common::{AppID, Application, Message};
 
 pub trait Trait: system::Trait {
 	type Event: From<Event<Self>> + Into<<Self as system::Trait>::Event>;
@@ -90,7 +88,7 @@ decl_module! {
 
 			let _ = T::Currency::deposit_creating(&to, amount);
 
-			Self::deposit_event(RawEvent::Minted(who, amount));
+			Self::deposit_event(RawEvent::Minted(to, amount));
 
 			Ok(())
 		}

--- a/parachain/pallets/polkaeth-app/src/mock.rs
+++ b/parachain/pallets/polkaeth-app/src/mock.rs
@@ -1,0 +1,113 @@
+// Mock runtime
+
+use crate::{Module, Trait};
+use sp_core::H256;
+use frame_support::traits::StorageMapShim;
+use frame_support::{impl_outer_origin, impl_outer_event, parameter_types, weights::Weight};
+use sp_runtime::{
+	traits::{BlakeTwo256, IdentityLookup}, testing::Header, Perbill,
+};
+use frame_system as system;
+use balances;
+
+impl_outer_origin! {
+	pub enum Origin for MockRuntime {}
+}
+
+mod test_events {
+    pub use crate::Event;
+}
+
+impl_outer_event! {
+    pub enum TestEvent for MockRuntime {
+        system<T>,
+        test_events<T>,
+        balances<T>,
+    }
+}
+
+pub type AccountId = u64;
+pub type Balance = u128;
+
+#[derive(Clone, Eq, PartialEq)]
+pub struct MockRuntime;
+
+parameter_types! {
+	pub const BlockHashCount: u64 = 250;
+	pub const MaximumBlockWeight: Weight = 1024;
+	pub const MaximumBlockLength: u32 = 2 * 1024;
+	pub const AvailableBlockRatio: Perbill = Perbill::from_percent(75);
+}
+
+impl system::Trait for MockRuntime {
+	type BaseCallFilter = ();
+	type Origin = Origin;
+	type Call = ();
+	type Index = u64;
+	type BlockNumber = u64;
+	type Hash = H256;
+	type Hashing = BlakeTwo256;
+	type AccountId = AccountId;
+	type Lookup = IdentityLookup<Self::AccountId>;
+	type Header = Header;
+	type Event = ();
+	type BlockHashCount = BlockHashCount;
+	type MaximumBlockWeight = MaximumBlockWeight;
+	type DbWeight = ();
+	type BlockExecutionWeight = ();
+	type ExtrinsicBaseWeight = ();
+	type MaximumExtrinsicWeight = MaximumBlockWeight;
+	type MaximumBlockLength = MaximumBlockLength;
+	type AvailableBlockRatio = AvailableBlockRatio;
+	type Version = ();
+	type ModuleToIndex = ();
+	type AccountData = ();
+	type OnNewAccount = ();
+	type OnKilledAccount = ();
+}
+
+parameter_types! {
+	pub const ExistentialDeposit: u128 = 500;
+}
+
+impl balances::Trait for MockRuntime {
+	type Balance = Balance;
+	type Event = ();
+	type DustRemoval = ();
+	type ExistentialDeposit = ExistentialDeposit;
+	type AccountStore = StorageMapShim<
+		balances::Account<MockRuntime>,
+		system::CallOnCreatedAccount<MockRuntime>,
+		system::CallKillAccount<MockRuntime>,
+		AccountId,
+		balances::AccountData<Balance>,
+	>;
+}
+
+impl Trait for MockRuntime {
+	type Event = ();
+	type Currency = balances::Module<MockRuntime>;
+}
+
+pub type PolkaETHModule = Module<MockRuntime>;
+pub type BalancesPolkaETH = balances::Module<MockRuntime>;
+
+pub const ALICE: AccountId = 1;
+pub const BOB: AccountId = 2;
+pub const CAROL: AccountId = 3;
+
+pub fn new_tester() -> sp_io::TestExternalities {
+	let mut storage = system::GenesisConfig::default().build_storage::<MockRuntime>().unwrap();
+
+	balances::GenesisConfig::<MockRuntime> {
+		balances: vec![
+			(ALICE, 1000),
+			(BOB, 1000),
+			(CAROL, 1000),
+		],
+	}
+	.assimilate_storage(&mut storage)
+	.unwrap();
+
+	storage.into()
+}

--- a/parachain/pallets/polkaeth-app/src/tests.rs
+++ b/parachain/pallets/polkaeth-app/src/tests.rs
@@ -1,0 +1,20 @@
+use crate::{mock::*};
+use frame_support::{assert_ok};
+
+#[test]
+fn it_mints() {
+	new_tester().execute_with(|| {
+		let origin = Origin::signed(ALICE);
+		assert_ok!(PolkaETHModule::mint(origin, BOB, 42));
+		assert_eq!(BalancesPolkaETH::free_balance(BOB), 1042);
+	});
+}
+
+#[test]
+fn it_burns() {
+	new_tester().execute_with(|| {
+		let origin = Origin::signed(ALICE);
+		assert_ok!(PolkaETHModule::burn(origin, 500, true));
+		assert_eq!(BalancesPolkaETH::free_balance(ALICE), 500);
+	});
+}


### PR DESCRIPTION
We're no longer emitting the event `AppEvent`, and neither are application modules depositing events into the bridge.