### PR TITLE
Remove obsolete bridge code

### DIFF
--- a/parachain/common/src/lib.rs
+++ b/parachain/common/src/lib.rs
@@ -14,7 +14,8 @@ pub use types::{AppID, Message};
 /// The bridge module implements this trait
 pub trait Bridge {
 
-    fn deposit_event(app_id: AppID, name: Vec<u8>, data: Vec<u8>);
+    // just a dummy stand-in until we flesh out this trait some more
+    fn dummy();
 
 }
 

--- a/parachain/pallets/bridge/src/lib.rs
+++ b/parachain/pallets/bridge/src/lib.rs
@@ -29,7 +29,6 @@ decl_event!(
 		Hash = <T as frame_system::Trait>::Hash,
 	{
 		MessageReceived(AccountId, AppID, Hash),
-		AppEvent(AppID, Vec<u8>, Vec<u8>),
 	}
 );
 
@@ -60,7 +59,7 @@ decl_module! {
 
 impl<T: Trait> Bridge for Module<T> {
 
-	fn deposit_event(app_id: AppID, name: Vec<u8>, data: Vec<u8>) {
-		Self::deposit_event(RawEvent::AppEvent(app_id, name, data));
+	fn dummy() {
+		()
 	}
 }


### PR DESCRIPTION
We're no longer emitting the event `AppEvent`, and neither are application modules depositing events into the bridge.