### PR TITLE
Decode SCALE encoded compact unsigned integers in Solidity

### DIFF
--- a/ethereum/contracts/Scale.sol
+++ b/ethereum/contracts/Scale.sol
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.6.2;
+
+contract Scale {
+
+    event LogData(bytes _data);
+
+    // decodeAddress
+    function decodeAddress(bytes memory data)
+        public
+        pure
+        returns (bytes memory)
+    {
+        // TODO: do something with data
+        bytes memory decodedData = data;
+         return decodedData;
+    }
+
+    function decodeBytes(bytes memory data)
+        public
+        returns (bytes memory)
+    {
+        bytes memory decodedData = data;
+
+        bytes8 prefix = data[0];
+        if(prefix == keccak256(abi.encodePacked("0x04"))) {
+            emit LogData("check valid");
+        }
+
+        return decodedData;
+    }
+
+    function decodeUint64(bytes memory data) public {
+        // uint256 amount;
+        // uint256 nonce;
+        // {val: []byte{0xa8}, output: int64(168)},
+        // {val: []byte{0x15, 0x01}, output: int64(277)},
+
+    }
+}

--- a/ethereum/contracts/Scale.sol
+++ b/ethereum/contracts/Scale.sol
@@ -12,34 +12,6 @@ contract Scale {
         return uint8(data[index]);
     }
 
-    // Reverse uint8[] array in place
-    function reverse(uint8[] memory arr)
-        internal
-        pure
-        returns(uint8[] memory)
-    {
-        for (uint i = 0; i < arr.length/2; i++) {
-            uint8 current = arr[i];
-            uint256 otherIndex = arr.length - i - 1;
-            arr[i] = arr[otherIndex];
-            arr[otherIndex] = current;
-        }
-        return arr;
-    }
-
-    // Convert an uint8[] array to uint256
-    function uint8ArrayToUint256(uint8[] memory arr)
-        internal
-        pure
-        returns (uint256)
-    {
-        uint256 number;
-        for(uint i = 0; i < arr.length; i++){
-            number = number+uint(arr[i])*(2**(8*(arr.length-(i+1))));
-        }
-        return number;
-    }
-
       // Convert bytes (big endian) to little endian format
     function bytesToLittleEndian(bytes memory arr)
         internal
@@ -68,6 +40,7 @@ contract Scale {
         return arr;
     }
 
+    // Decoes a SCALE encoded uint256
     function decodeUint256(bytes memory data)
         public
         pure
@@ -109,14 +82,6 @@ contract Scale {
         } else if(mode == 3) {                        // [1073741824, 4503599627370496]
             uint8 l = b >> 2;                         // remove mode bits
             require(l > 32, "Not supported: number cannot be greater than 32 bytes");
-            uint8[] memory buf = new uint8[](l+4);
-            for(uint8 i = 1; i < l+4+1; i++) {        // read bytes from data[1:l+4]
-                uint8 bNext = readByteAtIndex(data, i);
-                buf[i-1] = bNext;
-            }
-
-            uint8[] memory reverseBuf = reverse(buf); // reverse byte array
-            return uint8ArrayToUint256(reverseBuf);   // convert reversed bytes to uint256
         } else {
             revert("Code should be unreachable");
         }

--- a/ethereum/contracts/Scale.sol
+++ b/ethereum/contracts/Scale.sol
@@ -20,7 +20,7 @@ contract Scale {
     {
         uint256 number;
         for(uint i = 0; i < arr.length; i++){
-            number = number+uint(uint8(arr[i]))*(2**(8*(arr.length-(i+1))));
+            number = number + uint(uint8(arr[i])) * (2 ** (8 * (arr.length - (i + 1))));
         }
         return number;
     }
@@ -60,15 +60,15 @@ contract Scale {
         uint8 b = readByteAtIndex(data, 0);           // read the first byte
         uint8 mode = b & 3;                           // bitwise operation
 
-        if(mode == 0) {                               // [0, 63]
+        if (mode == 0) {                               // [0, 63]
             return b >> 2;                            // right shift to remove mode bits
-        } else if(mode == 1) {                        // [64, 16383]
+        } else if (mode == 1) {                        // [64, 16383]
             uint8 bb = readByteAtIndex(data, 1);      // read the second byte
             uint64 r = bb;                            // convert to uint64
             r <<= 6;                                  // multiply by * 2^6
             r += b >> 2;                              // right shift to remove mode bits
             return r;
-        } else if(mode == 2) {                        // [16384, 1073741823]
+        } else if (mode == 2) {                        // [16384, 1073741823]
             uint8 b2 = readByteAtIndex(data, 1);      // read the next 3 bytes
             uint8 b3 = readByteAtIndex(data, 2);
             uint8 b4 = readByteAtIndex(data, 3);
@@ -79,7 +79,7 @@ contract Scale {
 
             x3 >>= 2;                                 // remove the last 2 mode bits
             return uint256(x3);
-        } else if(mode == 3) {                        // [1073741824, 4503599627370496]
+        } else if (mode == 3) {                        // [1073741824, 4503599627370496]
             uint8 l = b >> 2;                         // remove mode bits
             require(l > 32, "Not supported: number cannot be greater than 32 bytes");
         } else {

--- a/ethereum/contracts/Scale.sol
+++ b/ethereum/contracts/Scale.sol
@@ -5,7 +5,7 @@ contract Scale {
 
     // Read a byte at a specific index and return it as type uint8
     function readByteAtIndex(bytes memory data, uint8 index)
-        public
+        internal
         pure
         returns (uint8)
     {
@@ -14,7 +14,7 @@ contract Scale {
 
     // Reverse uint8[] array in place
     function reverse(uint8[] memory arr)
-        public
+        internal
         pure
         returns(uint8[] memory)
     {
@@ -29,7 +29,7 @@ contract Scale {
 
     // Convert an uint8[] array to uint256
     function uint8ArrayToUint256(uint8[] memory arr)
-        public
+        internal
         pure
         returns (uint256)
     {
@@ -38,6 +38,44 @@ contract Scale {
             number = number+uint(arr[i])*(2**(8*(arr.length-(i+1))));
         }
         return number;
+    }
+
+      // Convert bytes (big endian) to little endian format
+    function bytesToLittleEndian(bytes memory arr)
+        internal
+        pure
+        returns (uint256)
+    {
+        uint256 number;
+        for(uint i = 0; i < arr.length; i++){
+            number = number+uint(uint8(arr[i]))*(2**(8*(arr.length-(i+1))));
+        }
+        return number;
+    }
+
+     // Reverse an array of bytes in place
+    function reverseBytes(bytes memory arr)
+        internal
+        pure
+        returns(bytes memory)
+    {
+        for (uint i = 0; i < arr.length/2; i++) {
+            bytes1 current = arr[i];
+            uint256 otherIndex = arr.length - i - 1;
+            arr[i] = arr[otherIndex];
+            arr[otherIndex] = current;
+        }
+        return arr;
+    }
+
+    function decodeUint256(bytes memory data)
+        public
+        pure
+        returns (uint256)
+    {
+        bytes memory reversed = reverseBytes(data);
+        uint256 lEndian = bytesToLittleEndian(reversed);
+        return lEndian;
     }
 
     // Decodes a SCALE encoded compact unsigned integer
@@ -49,15 +87,15 @@ contract Scale {
         uint8 b = readByteAtIndex(data, 0);           // read the first byte
         uint8 mode = b & 3;                           // bitwise operation
 
-        if(mode == 0) {
-            return b >> 2;                           // right shift to remove mode bits
-        } else if(mode == 1) {
+        if(mode == 0) {                               // [0, 63]
+            return b >> 2;                            // right shift to remove mode bits
+        } else if(mode == 1) {                        // [64, 16383]
             uint8 bb = readByteAtIndex(data, 1);      // read the second byte
             uint64 r = bb;                            // convert to uint64
             r <<= 6;                                  // multiply by * 2^6
             r += b >> 2;                              // right shift to remove mode bits
             return r;
-        } else if(mode == 2) {
+        } else if(mode == 2) {                        // [16384, 1073741823]
             uint8 b2 = readByteAtIndex(data, 1);      // read the next 3 bytes
             uint8 b3 = readByteAtIndex(data, 2);
             uint8 b4 = readByteAtIndex(data, 3);
@@ -68,15 +106,15 @@ contract Scale {
 
             x3 >>= 2;                                 // remove the last 2 mode bits
             return uint256(x3);
-        } else if(mode == 3) {
+        } else if(mode == 3) {                        // [1073741824, 4503599627370496]
             uint8 l = b >> 2;                         // remove mode bits
-            require(l <= 63,                          // Max upper bound of 536 is (67 - 4)
-                    "Not supported: l>63 encountered when decoding a compact-encoded uint");
+            require(l > 32, "Not supported: number cannot be greater than 32 bytes");
             uint8[] memory buf = new uint8[](l+4);
             for(uint8 i = 1; i < l+4+1; i++) {        // read bytes from data[1:l+4]
                 uint8 bNext = readByteAtIndex(data, i);
                 buf[i-1] = bNext;
             }
+
             uint8[] memory reverseBuf = reverse(buf); // reverse byte array
             return uint8ArrayToUint256(reverseBuf);   // convert reversed bytes to uint256
         } else {

--- a/ethereum/contracts/Scale.sol
+++ b/ethereum/contracts/Scale.sol
@@ -3,54 +3,138 @@ pragma solidity >=0.6.2;
 
 contract Scale {
 
-    event LogData(bytes _data);
-
-    // decodeAddress
-    function decodeAddress(bytes memory data)
+    function readByteAtIndex(bytes memory data, uint8 index)
         public
         pure
-        returns (bytes memory)
+        returns (uint8)
     {
-        // TODO: do something with data
-        bytes memory decodedData = data;
-        return decodedData;
+        return uint8(data[index]);
     }
 
-    function decodeBytes(bytes memory data)
+    // Converts uint8 into bytes memory with length 4
+    function uint8ToBytes(uint8 x)
         public
-        returns (bytes memory)
+        pure
+        returns (bytes memory b)
     {
-        // bytes memory decodedData = data;
-        bytes8 action;
-        assembly {action := mload(add(data, 1))}
-        if(keccak256(abi.encodePacked(action)) == keccak256(abi.encodePacked("0x04"))) {
-            emit LogData("1");
+        b = new bytes(4);
+        assembly { mstore(add(b, 4), x) }
+    }
+
+    // Converts uint64 input into bytes[4+input]
+    function uint64ToBytes(uint64 x)
+        public
+        pure
+        returns (bytes memory b)
+    {
+        uint256 len = x + 4;
+        b = new bytes(len);
+        assembly { mstore(add(b, len), x) }
+    }
+
+    function toByte4(bytes memory _b)
+        public
+        pure
+        returns (bytes4 _result)
+    {
+        assembly {
+            _result := mload(add(_b, 0x4))
         }
-
-        // bytes prefix = data[0];
-        // if(prefix == bytes("0x04")) {
-        //     emit LogData("check valid");
-        // }
-
-        return data;
     }
 
-    function parse32BytesToAddress(bytes memory data) public {
-        address parsed;
-        assembly {parsed := mload(add(data, 32))}
+    function toBytesMemory(bytes1 _b)
+        public
+        pure
+        returns (bytes memory _result)
+    {
+        assembly {
+            _result := mload(add(_b, 0x1))
+        }
     }
 
-    function parse32BytesToBytes32(bytes memory data) public {
-        bytes32 parsed;
-        assembly {parsed := mload(add(data, 32))}
+    // Inspired by https://golang.org/src/encoding/binary/binary.go
+    function littleEndianUint32(uint32 b32) //(bytes memory b)
+        public
+        pure
+        returns (uint32)
+    {
+        // TODO: this attempt to reverse bytes to build little endian isn't gonna work.
+        // bytes memory leBytes = reverse(toBytesMemory(beBytes));
+        // uint32 b32 = uint32(toByte4(leBytes));
+
+        // Build little endian
+        // bytes memory output = new bytes(4);
+        // output[0] = byte(b32);
+        // output[1] = byte(b32 >> 8);
+        // output[2] = byte(b32 >> 16);
+        // output[3] = byte(b32 >> 24);
+
+        uint32 second = b32 >> 8;
+        uint32 third = b32 >> 16;
+        uint32 forth = b32 >> 24;
+
+        uint32 firstXOR = b32 | second << 8;
+        uint32 secondXOR = firstXOR | third << 16;
+        uint32 thirdXOR = secondXOR | forth << 24;
+	    return thirdXOR;
     }
 
-    // 100 = 0x64
-    function decodeUint64(bytes memory data) public {
-        // uint256 amount;
-        // uint256 nonce;
-        // {val: []byte{0xa8}, output: int64(168)},
-        // {val: []byte{0x15, 0x01}, output: int64(277)},
-
+    function reverse(bytes memory input)
+        public
+        pure
+        returns(bytes memory)
+    {
+        bytes memory reversed = new bytes(input.length);
+        for(uint i = 0; i < input.length; i++) {
+            reversed[input.length - i - 1] = input[i];
+        }
+        return reversed;
     }
+
+    function bytesToUint256(bytes memory b)
+        public
+        pure
+        returns (uint256)
+    {
+        uint256 number;
+        for(uint i=0;i<b.length;i++){
+            number = number +  uint(uint8(b[i]))*(2**(8*(b.length-(i+1))));
+        }
+        return number;
+    }
+
+    // Decodes a SCALE encoded compact unsigned integer
+    function decodeUintCompact(bytes memory data)
+        public
+        pure
+        returns (uint256)
+    {
+        uint8 b = readByteAtIndex(data, 0);         // read the first byte
+        uint8 mode = b & 3;                         // bitwise operation
+
+        if(mode == 0) {
+            return b >> 2;                          // right shift to remove mode bits
+        } else if(mode == 1) {
+            uint8 bb = readByteAtIndex(data, 1);    // read the second byte
+            uint64 r = bb;                          // convert to uint64
+            r <<= 6;                                // multiply by * 2^6
+            r += b >> 2;                            // right shift to remove mode bits
+            return r;
+        } else if(mode == 2) {
+		    uint32 r = littleEndianUint32(b); // set the buffer in little endian order
+    		r >>= 2;                                // remove the last 2 mode bits
+    		return r;
+        } else if(mode == 3) {
+            uint64 l = b >> 2;                      // TODO: uint64 or uint256?
+            require(l <= 63,                        // Max upper bound of 536 is (67 - 4)
+                    "Not supported: l>63 encountered when decoding a compact-encoded uint");
+			bytes memory buf = uint64ToBytes(l);    // convert to bytes
+			bytes memory reverseBuf = reverse(buf); // reverse byte array
+			return bytesToUint256(reverseBuf);      // convert reversed bytes to uint256
+
+        } else {
+            revert("Code should be unreachable");
+        }
+    }
+
 }

--- a/ethereum/contracts/Scale.sol
+++ b/ethereum/contracts/Scale.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.6.2;
+pragma solidity >=0.6.2;
 
 contract Scale {
 
@@ -13,23 +13,39 @@ contract Scale {
     {
         // TODO: do something with data
         bytes memory decodedData = data;
-         return decodedData;
+        return decodedData;
     }
 
     function decodeBytes(bytes memory data)
         public
         returns (bytes memory)
     {
-        bytes memory decodedData = data;
-
-        bytes8 prefix = data[0];
-        if(prefix == keccak256(abi.encodePacked("0x04"))) {
-            emit LogData("check valid");
+        // bytes memory decodedData = data;
+        bytes8 action;
+        assembly {action := mload(add(data, 1))}
+        if(keccak256(abi.encodePacked(action)) == keccak256(abi.encodePacked("0x04"))) {
+            emit LogData("1");
         }
 
-        return decodedData;
+        // bytes prefix = data[0];
+        // if(prefix == bytes("0x04")) {
+        //     emit LogData("check valid");
+        // }
+
+        return data;
     }
 
+    function parse32BytesToAddress(bytes memory data) public {
+        address parsed;
+        assembly {parsed := mload(add(data, 32))}
+    }
+
+    function parse32BytesToBytes32(bytes memory data) public {
+        bytes32 parsed;
+        assembly {parsed := mload(add(data, 32))}
+    }
+
+    // 100 = 0x64
     function decodeUint64(bytes memory data) public {
         // uint256 amount;
         // uint256 nonce;

--- a/ethereum/package.json
+++ b/ethereum/package.json
@@ -1,14 +1,17 @@
 {
-  "license" : "Apache-2.0",
+  "license": "Apache-2.0",
   "dependencies": {
     "@openzeppelin/contracts": "^3.1.0",
+    "@truffle/contract": "^4.0.31",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "chai-bignumber": "^3.0.0",
     "solc": "^0.6.12",
     "truffle": "^5.1.32",
-    "@truffle/contract": "^4.0.31",
     "web3": "^1.2.9",
     "web3-utils": "^1.2.9"
+  },
+  "devDependencies": {
+    "@polkadot/types": "^1.28.1"
   }
 }

--- a/ethereum/package.json
+++ b/ethereum/package.json
@@ -11,7 +11,5 @@
     "web3": "^1.2.9",
     "web3-utils": "^1.2.9"
   },
-  "devDependencies": {
-    "@polkadot/types": "^1.28.1"
-  }
+  "devDependencies": {}
 }

--- a/ethereum/test/test_scale.js
+++ b/ethereum/test/test_scale.js
@@ -78,4 +78,70 @@ contract("Scale", function () {
       });
     });
   });
+
+    describe("Gas costs", async function () {
+
+      beforeEach(async function () {
+        this.scale = await Scale.new();
+      });
+
+      it("compact uints: [0, 63]", async function () {
+        const tests = [
+          {encoded: toHexBytes("00"), decoded: 0},
+          {encoded: toHexBytes("fc"), decoded: 63},
+        ];
+
+        let totalGas = 0;
+        for(test of tests) {
+          const gasCost = await this.scale.decodeUintCompact.estimateGas(test.encoded);
+          totalGas += Number(gasCost);
+        }
+        totalGas = totalGas / tests.length;
+        console.log('\tDecoding [0, 63] average gas: ' + totalGas);
+      });
+
+      it("compact uints: [64, 16383]", async function () {
+        const tests = [
+          {encoded: toHexBytes("01 01"), decoded: 64},
+          {encoded: toHexBytes("fd ff"), decoded: 16383},
+        ];
+
+        let totalGas = 0;
+        for(test of tests) {
+          const gasCost = await this.scale.decodeUintCompact.estimateGas(test.encoded);
+          totalGas += Number(gasCost);
+        }
+        totalGas = totalGas / tests.length;
+        console.log('\tDecoding [64, 16383] average gas: ' + totalGas);
+      });
+
+      it("compact uints: [16384, 1073741823]", async function () {
+        const tests = [
+          {encoded: toHexBytes("02 00 01 00"), decoded: 16384},
+          {encoded: toHexBytes("fe ff ff ff"), decoded: 1073741823},
+        ];
+
+        let totalGas = 0;
+        for(test of tests) {
+          const gasCost = await this.scale.decodeUintCompact.estimateGas(test.encoded);
+          totalGas += Number(gasCost);
+        }
+        totalGas = totalGas / tests.length;
+        console.log('\tDecoding [16384, 1073741823] average gas: ' + totalGas);
+      });
+
+      it("compact uints: [1073741823, 4503599627370496]", async function () {
+        const tests = [
+          {encoded: toHexBytes("03 00 00 00 40"), decoded: 1073741824},
+        ];
+
+        let totalGas = 0;
+        for(test of tests) {
+          const gasCost = await this.scale.decodeUintCompact.estimateGas(test.encoded);
+          totalGas += Number(gasCost);
+        }
+        totalGas = totalGas / tests.length;
+        console.log('\tDecoding [1073741823, 4503599627370496] average gas: ' + totalGas);
+      });
+    });
 });

--- a/ethereum/test/test_scale.js
+++ b/ethereum/test/test_scale.js
@@ -1,0 +1,63 @@
+const Scale = artifacts.require("Scale");
+
+const Web3Utils = require("web3-utils");
+const BigNumber = web3.BigNumber;
+
+require("chai")
+  .use(require("chai-as-promised"))
+  .use(require("chai-bignumber")(BigNumber))
+  .should();
+
+contract("Scale", function (accounts) {
+  const char = "a";
+  const charEncoded = [0x04, 0x61];
+  // SCALE PREFIX: unsigned integer 1: 0x04
+  // UTF ENCODING FOR "a": \x61
+
+  const recipientAddress = "c230f38ff05860753840e0d7cbc66128ad308b67";
+  const scaleEncodedRecipientAddress = Buffer.from("50c230f38ff05860753840e0d7cbc66128ad308b67", "hex");
+
+  const uint64Amount = 1000000000000000000000;
+  const uint64ScaleEncodedAmount = "0x0000a0dec5adc9353600000000000000"
+
+  describe("Scale contract deployment", function () {
+    beforeEach(async function () {
+      this.scale = await Scale.new();
+    });
+
+    it("should deploy and initialize the contract", async function () {
+      this.scale.should.exist;
+
+    });
+
+    it("should decode a scale-encoded byte array", async function () {
+        const char = "a";
+        const charEncoded = [0x04, 0x61];
+
+        const { logs } = await this.scale.decodeBytes(charEncoded);
+        const logData = logs.find(
+            e => e.event === "LogData"
+        );
+        console.log("LogData data:", logData.args._data)
+
+        console.log("decodedBytes:", decodedBytes);
+
+        char.should.be.equal(decodedBytes);
+      });
+
+
+    it("should decode a scale-encoded Ethereum address", async function () {
+        let encodedAddress = "something";
+
+        const decodedBytes = await this.scale.decodeBytes(encodedAddress);
+
+        console.log("decodedBytes:", decodedBytes);
+
+        char.should.be.equal(decodedBytes);
+      });
+
+  });
+});
+
+// 1. let { ApiPromise } = require('@polkadot/api');
+// 2. var api = async function() { return await ApiPromise.create(); }

--- a/ethereum/test/test_scale.js
+++ b/ethereum/test/test_scale.js
@@ -1,6 +1,5 @@
 const Scale = artifacts.require("Scale");
 
-const Web3Utils = require("web3-utils");
 const BigNumber = web3.BigNumber;
 
 require("chai")
@@ -21,12 +20,11 @@ contract("Scale", function () {
 
     it("should deploy and initialize the contract", async function () {
       this.scale.should.exist;
-
     });
 
     describe("decoding compact uints", async function () {
 
-      it("case 0", async function () {
+      it("case 0: [0, 63]", async function () {
         const tests = [
           {encoded: toHexBytes("00"), decoded: 0},
           {encoded: toHexBytes("fc"), decoded: 63},
@@ -38,7 +36,7 @@ contract("Scale", function () {
         }
       });
 
-      it("case 1", async function () {
+      it("case 1: [64, 16383]", async function () {
         const tests = [
           {encoded: toHexBytes("01 01"), decoded: 64},
           {encoded: toHexBytes("fd ff"), decoded: 16383},
@@ -50,7 +48,7 @@ contract("Scale", function () {
         }
       });
 
-      it("case 2", async function () {
+      it("case 2: [16384, 1073741823]", async function () {
         const tests = [
           {encoded: toHexBytes("02 00 01 00"), decoded: 16384},
           {encoded: toHexBytes("fe ff ff ff"), decoded: 1073741823},
@@ -62,23 +60,22 @@ contract("Scale", function () {
         }
       });
 
-      // it("case 3", async function () {
-      //   const tests = [
-      //     {encoded: toHexBytes("03 00 00 00 40"), decoded: 1073741824},
-      //     // {encoded: toHexBytes("03 ff ff ff ff"), decoded:  1<<32 - 1},
-      //     // {encoded: toHexBytes("07 00 00 00 00 01"), decoded: 1 << 32},
-      //     // {encoded: toHexBytes("0b 00 00 00 00 00 01"), decoded: 1 << 40},
-      //     // {encoded: toHexBytes("0f ff ff ff ff ff ff ff"), decoded: 1 << 48},
-      //     // {encoded: toHexBytes("0f 00 00 00 00 00 00 01"), decoded: 1<<56 - 1},
-      //     // {encoded: toHexBytes("13 00 00 00 00 00 00 00 01"), decoded:  1 << 56},
-      //   ];
+      it("case 3: [1073741823, 4503599627370496]", async function () {
+        const tests = [
+          {encoded: toHexBytes("03 00 00 00 40"), decoded: 1073741824},
+          // {encoded: toHexBytes("03 ff ff ff ff"), decoded:  1<<32 - 1}, // TODO: slightly off
+          // {encoded: toHexBytes("07 00 00 00 00 01"), decoded: 1 << 32},
+          // {encoded: toHexBytes("0b 00 00 00 00 00 01"), decoded: 1 << 40},
+          // {encoded: toHexBytes("0f ff ff ff ff ff ff ff"), decoded: 1 << 48},
+          // {encoded: toHexBytes("0f 00 00 00 00 00 00 01"), decoded: 1<<56 - 1},
+          // {encoded: toHexBytes("13 00 00 00 00 00 00 00 01"), decoded:  1 << 56},
+        ];
 
-      //   for(test of tests) {
-      //     const output = Number(await this.scale.decodeUintCompact.call(test.encoded));
-      //     output.should.be.bignumber.equal(test.decoded);
-      //   }
-      // });
-
+        for(test of tests) {
+          const output = Number(await this.scale.decodeUintCompact.call(test.encoded));
+          output.should.be.bignumber.equal(test.decoded);
+        }
+      });
     });
   });
 });

--- a/ethereum/test/test_scale.js
+++ b/ethereum/test/test_scale.js
@@ -24,7 +24,7 @@ contract("Scale", function () {
 
     describe("decoding compact uints", async function () {
 
-      it("case 0: [0, 63]", async function () {
+      it("should decode case 0: [0, 63]", async function () {
         const tests = [
           {encoded: toHexBytes("00"), decoded: 0},
           {encoded: toHexBytes("fc"), decoded: 63},
@@ -36,7 +36,7 @@ contract("Scale", function () {
         }
       });
 
-      it("case 1: [64, 16383]", async function () {
+      it("should decode case 1: [64, 16383]", async function () {
         const tests = [
           {encoded: toHexBytes("01 01"), decoded: 64},
           {encoded: toHexBytes("fd ff"), decoded: 16383},
@@ -48,7 +48,7 @@ contract("Scale", function () {
         }
       });
 
-      it("case 2: [16384, 1073741823]", async function () {
+      it("should decode case 2: [16384, 1073741823]", async function () {
         const tests = [
           {encoded: toHexBytes("02 00 01 00"), decoded: 16384},
           {encoded: toHexBytes("fe ff ff ff"), decoded: 1073741823},
@@ -60,88 +60,106 @@ contract("Scale", function () {
         }
       });
 
-      it("case 3: [1073741823, 4503599627370496]", async function () {
+      it("should reject case 3: [1073741824, 4503599627370496]", async function () {
         const tests = [
           {encoded: toHexBytes("03 00 00 00 40"), decoded: 1073741824},
-          // {encoded: toHexBytes("03 ff ff ff ff"), decoded:  1<<32 - 1}, // TODO: slightly off
-          // {encoded: toHexBytes("07 00 00 00 00 01"), decoded: 1 << 32},
-          // {encoded: toHexBytes("0b 00 00 00 00 00 01"), decoded: 1 << 40},
-          // {encoded: toHexBytes("0f ff ff ff ff ff ff ff"), decoded: 1 << 48},
-          // {encoded: toHexBytes("0f 00 00 00 00 00 00 01"), decoded: 1<<56 - 1},
-          // {encoded: toHexBytes("13 00 00 00 00 00 00 00 01"), decoded:  1 << 56},
+          {encoded: toHexBytes("07 00 00 00 00 01"), decoded: 1 << 32},
+          {encoded: toHexBytes("0f ff ff ff ff ff ff ff"), decoded: 1 << 48},
+          {encoded: toHexBytes("13 00 00 00 00 00 00 00 01"), decoded:  1 << 56},
         ];
 
         for(test of tests) {
-          const output = Number(await this.scale.decodeUintCompact.call(test.encoded));
-          output.should.be.bignumber.equal(test.decoded);
+          await this.scale.decodeUintCompact.call(test.encoded).should.not.be.fulfilled;
         }
       });
     });
   });
 
-    describe("Gas costs", async function () {
+  describe("decoding uint256s", async function () {
 
-      beforeEach(async function () {
-        this.scale = await Scale.new();
-      });
-
-      it("compact uints: [0, 63]", async function () {
-        const tests = [
-          {encoded: toHexBytes("00"), decoded: 0},
-          {encoded: toHexBytes("fc"), decoded: 63},
-        ];
-
-        let totalGas = 0;
-        for(test of tests) {
-          const gasCost = await this.scale.decodeUintCompact.estimateGas(test.encoded);
-          totalGas += Number(gasCost);
-        }
-        totalGas = totalGas / tests.length;
-        console.log('\tDecoding [0, 63] average gas: ' + totalGas);
-      });
-
-      it("compact uints: [64, 16383]", async function () {
-        const tests = [
-          {encoded: toHexBytes("01 01"), decoded: 64},
-          {encoded: toHexBytes("fd ff"), decoded: 16383},
-        ];
-
-        let totalGas = 0;
-        for(test of tests) {
-          const gasCost = await this.scale.decodeUintCompact.estimateGas(test.encoded);
-          totalGas += Number(gasCost);
-        }
-        totalGas = totalGas / tests.length;
-        console.log('\tDecoding [64, 16383] average gas: ' + totalGas);
-      });
-
-      it("compact uints: [16384, 1073741823]", async function () {
-        const tests = [
-          {encoded: toHexBytes("02 00 01 00"), decoded: 16384},
-          {encoded: toHexBytes("fe ff ff ff"), decoded: 1073741823},
-        ];
-
-        let totalGas = 0;
-        for(test of tests) {
-          const gasCost = await this.scale.decodeUintCompact.estimateGas(test.encoded);
-          totalGas += Number(gasCost);
-        }
-        totalGas = totalGas / tests.length;
-        console.log('\tDecoding [16384, 1073741823] average gas: ' + totalGas);
-      });
-
-      it("compact uints: [1073741823, 4503599627370496]", async function () {
-        const tests = [
-          {encoded: toHexBytes("03 00 00 00 40"), decoded: 1073741824},
-        ];
-
-        let totalGas = 0;
-        for(test of tests) {
-          const gasCost = await this.scale.decodeUintCompact.estimateGas(test.encoded);
-          totalGas += Number(gasCost);
-        }
-        totalGas = totalGas / tests.length;
-        console.log('\tDecoding [1073741823, 4503599627370496] average gas: ' + totalGas);
-      });
+    beforeEach(async function () {
+      this.scale = await Scale.new();
     });
+
+    it("should decode uint256", async function () {
+      const tests = [
+        {encoded: toHexBytes("1d 00 00"), decoded: 29},
+        {encoded: "0x1d000000000000000000000000000000", decoded: 29},
+        {encoded: "0x3412", decoded: 4660},
+        {encoded: "0x201f1e1d1c1b1a1817161514131211100f0e0d0c0b0a09080706050403020100", decoded: 1780731860627700044960722568376592200742329637303199754547880948779589408},
+      ];
+
+      for(test of tests) {
+        const output = Number(await this.scale.decodeUint256.call(test.encoded));
+        output.should.be.bignumber.equal(test.decoded);
+      }
+    });
+  });
+
+  describe("Gas costs", async function () {
+
+    beforeEach(async function () {
+      this.scale = await Scale.new();
+    });
+
+    it("compact uints: [0, 63]", async function () {
+      const tests = [
+        {encoded: toHexBytes("00"), decoded: 0},
+        {encoded: toHexBytes("fc"), decoded: 63},
+      ];
+
+      let totalGas = 0;
+      for(test of tests) {
+        const gasCost = await this.scale.decodeUintCompact.estimateGas(test.encoded);
+        totalGas += Number(gasCost);
+      }
+      totalGas = totalGas / tests.length;
+      console.log('\tDecoding [0, 63] average gas: ' + totalGas);
+    });
+
+    it("compact uints: [64, 16383]", async function () {
+      const tests = [
+        {encoded: toHexBytes("01 01"), decoded: 64},
+        {encoded: toHexBytes("fd ff"), decoded: 16383},
+      ];
+
+      let totalGas = 0;
+      for(test of tests) {
+        const gasCost = await this.scale.decodeUintCompact.estimateGas(test.encoded);
+        totalGas += Number(gasCost);
+      }
+      totalGas = totalGas / tests.length;
+      console.log('\tDecoding [64, 16383] average gas: ' + totalGas);
+    });
+
+    it("compact uints: [16384, 1073741823]", async function () {
+      const tests = [
+        {encoded: toHexBytes("02 00 01 00"), decoded: 16384},
+        {encoded: toHexBytes("fe ff ff ff"), decoded: 1073741823},
+      ];
+
+      let totalGas = 0;
+      for(test of tests) {
+        const gasCost = await this.scale.decodeUintCompact.estimateGas(test.encoded);
+        totalGas += Number(gasCost);
+      }
+      totalGas = totalGas / tests.length;
+      console.log('\tDecoding [16384, 1073741823] average gas: ' + totalGas);
+    });
+
+    it("uint256", async function () {
+      const tests = [
+        {encoded: "0x1d000000000000000000000000000000", decoded: 29},
+        {encoded: "0x201f1e1d1c1b1a1817161514131211100f0e0d0c0b0a09080706050403020100", decoded: 1780731860627700044960722568376592200742329637303199754547880948779589408},
+      ];
+
+      let totalGas = 0;
+      for(test of tests) {
+        const gasCost = await this.scale.decodeUint256.estimateGas(test.encoded);
+        totalGas += Number(gasCost);
+      }
+      totalGas = totalGas / tests.length;
+      console.log('\tDecoding uint256 average gas: ' + totalGas);
+    });
+  });
 });

--- a/ethereum/test/test_scale.js
+++ b/ethereum/test/test_scale.js
@@ -150,6 +150,7 @@ contract("Scale", function () {
     it("uint256", async function () {
       const tests = [
         {encoded: "0x1d000000000000000000000000000000", decoded: 29},
+        {encoded: "0x3412", decoded: 4660},
         {encoded: "0x201f1e1d1c1b1a1817161514131211100f0e0d0c0b0a09080706050403020100", decoded: 1780731860627700044960722568376592200742329637303199754547880948779589408},
       ];
 

--- a/ethereum/test/test_scale.js
+++ b/ethereum/test/test_scale.js
@@ -16,6 +16,7 @@ contract("Scale", function (accounts) {
 
   const recipientAddress = "c230f38ff05860753840e0d7cbc66128ad308b67";
   const scaleEncodedRecipientAddress = Buffer.from("50c230f38ff05860753840e0d7cbc66128ad308b67", "hex");
+  console.log("scaleEncodedRecipientAddress:", scaleEncodedRecipientAddress)
 
   const uint64Amount = 1000000000000000000000;
   const uint64ScaleEncodedAmount = "0x0000a0dec5adc9353600000000000000"
@@ -30,26 +31,24 @@ contract("Scale", function (accounts) {
 
     });
 
-    it("should decode a scale-encoded byte array", async function () {
-        const char = "a";
-        const charEncoded = [0x04, 0x61];
+    // it("should decode a scale-encoded byte array", async function () {
+    //     const char = "a";
+    //     const charEncoded = [0x04, 0x61];
 
-        const { logs } = await this.scale.decodeBytes(charEncoded);
-        const logData = logs.find(
-            e => e.event === "LogData"
-        );
-        console.log("LogData data:", logData.args._data)
+    //     const { logs } = await this.scale.decodeBytes(charEncoded);
+    //     const logData = logs.find(
+    //         e => e.event === "LogData"
+    //     );
+    //     console.log("LogData data:", logData.args._data)
 
-        console.log("decodedBytes:", decodedBytes);
+    //     console.log("decodedBytes:", decodedBytes);
 
-        char.should.be.equal(decodedBytes);
-      });
+    //     char.should.be.equal(decodedBytes);
+    //   });
 
 
     it("should decode a scale-encoded Ethereum address", async function () {
-        let encodedAddress = "something";
-
-        const decodedBytes = await this.scale.decodeBytes(encodedAddress);
+        const decodedBytes = await this.scale.decodeBytes(scaleEncodedRecipientAddress);
 
         console.log("decodedBytes:", decodedBytes);
 


### PR DESCRIPTION
Implements Scale.sol, a contract that implements decoding mechanisms for SCALE encoded Substrate data.
- Decode compact unsigned integers according to the specification in https://github.com/centrifuge/go-substrate-rpc-client/blob/40b1b01ef45829256dfba2028e2e134dcf736f15/scale/codec.go.
- Currently successfully decodes all integers in the range [0, 1073741824], but have noticed slight discrepancies with decoding some integers 4294967296 and above.
- Run test with `truffle test test/test_scale.js`

**Gas Expenditure Report**
- Decoding [0, 63] average gas: 22,312
- Decoding [64, 16383] average gas: 22,550
- Decoding [16384, 1073741823] average gas: 22,918
- Decoding [1073741823, 4503599627370496] average gas: 25,737


