### PR TITLE
Generic asset pallet and relayed events

### DIFF
--- a/parachain/Cargo.lock
+++ b/parachain/Cargo.lock
@@ -121,6 +121,7 @@ dependencies = [
  "frame-support",
  "parity-scale-codec",
  "rustc-hex",
+ "sp-core",
  "sp-std",
 ]
 
@@ -137,6 +138,24 @@ dependencies = [
  "serde",
  "sp-core",
  "sp-io",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
+name = "artemis-generic-asset"
+version = "0.1.1"
+dependencies = [
+ "artemis-core",
+ "artemis-ethereum",
+ "frame-support",
+ "frame-system",
+ "parity-scale-codec",
+ "rustc-hex",
+ "serde",
+ "sp-core",
+ "sp-io",
+ "sp-keyring",
  "sp-runtime",
  "sp-std",
 ]
@@ -174,6 +193,7 @@ dependencies = [
 name = "artemis-runtime"
 version = "0.1.1"
 dependencies = [
+ "artemis-generic-asset",
  "frame-executive",
  "frame-support",
  "frame-system",
@@ -3584,8 +3604,10 @@ version = "0.1.1"
 dependencies = [
  "artemis-core",
  "artemis-ethereum",
+ "artemis-generic-asset",
  "frame-support",
  "frame-system",
+ "pallet-bridge",
  "parity-scale-codec",
  "rustc-hex",
  "serde",
@@ -3602,9 +3624,11 @@ version = "0.1.1"
 dependencies = [
  "artemis-core",
  "artemis-ethereum",
+ "artemis-generic-asset",
  "frame-support",
  "frame-system",
  "pallet-balances",
+ "pallet-bridge",
  "parity-scale-codec",
  "rustc-hex",
  "serde",

--- a/parachain/Cargo.toml
+++ b/parachain/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     'primitives/ethereum',
     'pallets/bridge',
     'pallets/broker',
+    'pallets/generic-asset',
     'pallets/dummy-verifier',
     'pallets/polkaeth-app',
     'pallets/polkaerc20-app',

--- a/parachain/node/src/chain_spec.rs
+++ b/parachain/node/src/chain_spec.rs
@@ -1,7 +1,7 @@
 use sp_core::{Pair, Public, sr25519};
 use artemis_runtime::{
 	AccountId, AuraConfig, BalancesConfig, GenesisConfig, GrandpaConfig,
-	SudoConfig, SystemConfig, BalancesPolkaETHConfig, WASM_BINARY, Signature
+	SudoConfig, SystemConfig, WASM_BINARY, Signature
 };
 use sp_consensus_aura::sr25519::AuthorityId as AuraId;
 use sp_finality_grandpa::AuthorityId as GrandpaId;
@@ -110,9 +110,6 @@ fn testnet_genesis(initial_authorities: Vec<(AuraId, GrandpaId)>,
 		}),
 		balances: Some(BalancesConfig {
 			balances: endowed_accounts.iter().cloned().map(|k|(k, 1 << 60)).collect(),
-		}),
-		balances_Instance2: Some(BalancesPolkaETHConfig {
-			balances: vec![],
 		}),
 		aura: Some(AuraConfig {
 			authorities: initial_authorities.iter().map(|x| (x.0.clone())).collect(),

--- a/parachain/pallets/broker/src/lib.rs
+++ b/parachain/pallets/broker/src/lib.rs
@@ -15,8 +15,8 @@ pub trait Trait: system::Trait {
 	type Event: From<Event> + Into<<Self as system::Trait>::Event>;
 
 	type DummyVerifier: Verifier;
-	type PolkaETH: Application;
-	type PolkaERC20: Application;
+	type AppETH: Application;
+	type AppERC20: Application;
 }
 
 decl_storage! {
@@ -67,10 +67,10 @@ impl<T: Trait> Module<T> {
 		for entry in REGISTRY.iter() {
 			match entry.symbol {
 				AppName::PolkaETH => {
-					T::PolkaETH::handle(app_id, message.clone())?;
+					T::AppETH::handle(app_id, message.clone())?;
 				}
 				AppName::PolkaERC20 => {
-					T::PolkaERC20::handle(app_id, message.clone())?;
+					T::AppERC20::handle(app_id, message.clone())?;
 				}
 			};
 		}

--- a/parachain/pallets/generic-asset/Cargo.toml
+++ b/parachain/pallets/generic-asset/Cargo.toml
@@ -1,0 +1,89 @@
+[package]
+name = "artemis-generic-asset"
+version = "0.1.1"
+authors = ["Snowfork <contact@snowfork.com>"]
+edition = "2018"
+
+[package.metadata.docs.rs]
+targets = ['x86_64-unknown-linux-gnu']
+
+[dependencies]
+hex = { package = "rustc-hex", version = "2.1.0", default-features = false }
+
+[dependencies.codec]
+default-features = false
+features = ['derive']
+package = 'parity-scale-codec'
+version = '1.3.1'
+
+[dependencies.frame-support]
+default-features = false
+git = 'https://github.com/paritytech/substrate.git'
+tag = 'v2.0.0-rc4'
+version = '2.0.0-rc4'
+
+[dependencies.frame-system]
+default-features = false
+git = 'https://github.com/paritytech/substrate.git'
+tag = 'v2.0.0-rc4'
+version = '2.0.0-rc4'
+
+[dependencies.sp-core]
+default-features = false
+git = 'https://github.com/paritytech/substrate.git'
+tag = 'v2.0.0-rc4'
+version = '2.0.0-rc4'
+
+[dependencies.sp-std]
+default-features = false
+git = 'https://github.com/paritytech/substrate.git'
+tag = 'v2.0.0-rc4'
+version = '2.0.0-rc4'
+
+[dependencies.sp-io]
+default-features = false
+git = 'https://github.com/paritytech/substrate.git'
+tag = 'v2.0.0-rc4'
+version = '2.0.0-rc4'
+
+[dependencies.sp-runtime]
+default-features = false
+git = 'https://github.com/paritytech/substrate.git'
+tag = 'v2.0.0-rc4'
+version = '2.0.0-rc4'
+
+[dev-dependencies.sp-keyring]
+default-features = false
+git = 'https://github.com/paritytech/substrate.git'
+tag = 'v2.0.0-rc4'
+version = '2.0.0-rc4'
+
+[dependencies.serde]
+package = 'serde'
+optional = true
+version = '1.0.101'
+features = ["derive"]
+
+[dependencies.artemis-core]
+default-features = false
+path = "../../primitives/core"
+
+[dependencies.artemis-ethereum]
+default-features = false
+path = "../../primitives/ethereum"
+
+[features]
+default = ['std']
+std = [
+    'hex/std',
+    'serde',
+    'codec/std',
+    'frame-support/std',
+    'frame-system/std',
+    'sp-core/std',
+    'sp-std/std',
+    'sp-io/std',
+    'sp-runtime/std',
+    'artemis-core/std',
+    'artemis-ethereum/std'
+]

--- a/parachain/pallets/generic-asset/src/lib.rs
+++ b/parachain/pallets/generic-asset/src/lib.rs
@@ -3,21 +3,14 @@
 /// Implementation for PolkaERC20 token assets
 ///
 use sp_std::prelude::*;
-use sp_std::{fmt::Debug, convert::TryInto};
 use sp_core::{H160, U256, RuntimeDebug};
-use sp_runtime::traits::{
-	CheckedAdd, MaybeSerializeDeserialize, Member,  AtLeast32BitUnsigned};
-use frame_system::{self as system};
+use frame_system::{self as system, ensure_signed};
 use frame_support::{
-	decl_error, decl_event, decl_module, decl_storage, Parameter,
+	decl_error, decl_event, decl_module, decl_storage,
 	dispatch::{DispatchResult, DispatchError},
-	storage::StorageDoubleMap
 };
 
-use codec::{Decode};
-
-use artemis_core::{AppID, Application, Message};
-use artemis_ethereum::{self as ethereum, SignedMessage};
+use codec::{Encode, Decode};
 
 #[cfg(test)]
 mod mock;
@@ -33,12 +26,12 @@ pub struct AccountData {
 }
 
 pub trait Trait: system::Trait {
-	type Event: From<Event<Self, I>> + Into<<Self as system::Trait>::Event>;
+	type Event: From<Event<Self>> + Into<<Self as system::Trait>::Event>;
 }
 
 decl_storage! {
 	trait Store for Module<T: Trait> as GenericAsset {
-		pub TotalIssuance: double_map hasher(blake2_128_concat) AssetId, hasher(blake2_128_concat) T::AccountId => U256;
+		pub TotalIssuance: map        hasher(blake2_128_concat) AssetId => U256;
 		pub Account:       double_map hasher(blake2_128_concat) AssetId, hasher(blake2_128_concat) T::AccountId => AccountData;
 	}
 }
@@ -50,11 +43,14 @@ decl_event!(
 	{
 		Burned(AssetId, AccountId, U256),
 		Minted(AssetId, AccountId, U256),
+		Transferred(AssetId, AccountId, AccountId, U256),
 	}
 );
 
 decl_error! {
 	pub enum Error for Module<T: Trait> {
+		/// Free balance got overflowed after transfer.
+		FreeTransferOverflow,
 		/// Total issuance got overflowed after minting.
 		TotalMintingOverflow,
 		/// Free balance got overflowed after minting.
@@ -63,20 +59,87 @@ decl_error! {
 		TotalBurningUnderflow,
 		/// Free balance got underflowed after burning.
 		FreeBurningUnderflow,
+		InsufficientBalance,
 	}
 }
 
 decl_module! {
 
-	pub struct Module<T: Trait<I>, I: Instance> for enum Call where origin: T::Origin {
+	pub struct Module<T: Trait> for enum Call where origin: T::Origin {
 
 		type Error = Error<T>;
 
 		fn deposit_event() = default;
 
+		/// Transfer some liquid free balance to another account.
+		#[weight = 0]
+		pub fn transfer(origin, asset_id: AssetId, to: T::AccountId, amount: U256) -> DispatchResult {
+			let origin = ensure_signed(origin)?;
+			Self::do_transfer(asset_id, &origin, &to, amount)?;
+			Ok(())
+		}
+
 	}
 }
 
 impl<T: Trait> Module<T> {
+
+	pub fn free_balance(asset_id: AssetId, who: &T::AccountId) -> U256 {
+		<Account<T>>::get(asset_id, who).free
+	}
+
+	pub fn do_mint(asset_id: AssetId, who: &T::AccountId, amount: U256) -> DispatchResult  {
+		if amount.is_zero() {
+			return Ok(())
+		}
+		<Account<T>>::try_mutate(asset_id, who, |account| -> Result<(), DispatchError> {
+			let current_total_issuance = <TotalIssuance>::get(asset_id);
+			let new_total_issuance = current_total_issuance.checked_add(amount)
+			.ok_or(Error::<T>::TotalMintingOverflow)?;
+			account.free = account.free.checked_add(amount)
+				.ok_or(Error::<T>::FreeMintingOverflow)?;
+			<TotalIssuance>::insert(asset_id, new_total_issuance);
+			Ok(())
+		})?;
+		Self::deposit_event(RawEvent::Minted(asset_id, who.clone(), amount));
+		Ok(())
+	}
+
+	pub fn do_burn(asset_id: AssetId, who: &T::AccountId, amount: U256) -> DispatchResult  {
+		if amount.is_zero() {
+			return Ok(())
+		}
+		<Account<T>>::try_mutate(asset_id, who, |account| -> Result<(), DispatchError> {
+			let current_total_issuance = <TotalIssuance>::get(asset_id);
+			let new_total_issuance = current_total_issuance.checked_sub(amount)
+			.ok_or(Error::<T>::TotalBurningUnderflow)?;
+			account.free = account.free.checked_sub(amount)
+				.ok_or(Error::<T>::FreeBurningUnderflow)?;
+			<TotalIssuance>::insert(asset_id, new_total_issuance);
+			Ok(())
+		})?;
+		Self::deposit_event(RawEvent::Burned(asset_id, who.clone(), amount));
+		Ok(())
+	}
+
+	pub fn do_transfer(
+		asset_id: AssetId,
+		from: &T::AccountId,
+		to: &T::AccountId,
+		amount: U256)
+	-> DispatchResult {
+		if amount.is_zero() || from == to {
+			return Ok(())
+		}
+		<Account<T>>::try_mutate(asset_id, from, |from_account| -> DispatchResult {
+			<Account<T>>::try_mutate(asset_id, to, |to_account| -> DispatchResult {
+				from_account.free = from_account.free.checked_sub(amount).ok_or(Error::<T>::InsufficientBalance)?;
+				to_account.free = to_account.free.checked_add(amount).ok_or(Error::<T>::FreeTransferOverflow)?;
+				Ok(())
+			})
+		})?;
+		Self::deposit_event(RawEvent::Transferred(asset_id, from.clone(), to.clone(), amount));
+		Ok(())
+	}
 
 }

--- a/parachain/pallets/generic-asset/src/lib.rs
+++ b/parachain/pallets/generic-asset/src/lib.rs
@@ -1,0 +1,82 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+///
+/// Implementation for PolkaERC20 token assets
+///
+use sp_std::prelude::*;
+use sp_std::{fmt::Debug, convert::TryInto};
+use sp_core::{H160, U256, RuntimeDebug};
+use sp_runtime::traits::{
+	CheckedAdd, MaybeSerializeDeserialize, Member,  AtLeast32BitUnsigned};
+use frame_system::{self as system};
+use frame_support::{
+	decl_error, decl_event, decl_module, decl_storage, Parameter,
+	dispatch::{DispatchResult, DispatchError},
+	storage::StorageDoubleMap
+};
+
+use codec::{Decode};
+
+use artemis_core::{AppID, Application, Message};
+use artemis_ethereum::{self as ethereum, SignedMessage};
+
+#[cfg(test)]
+mod mock;
+
+#[cfg(test)]
+mod tests;
+
+type AssetId = H160;
+
+#[derive(Encode, Decode, Clone, PartialEq, Eq, Default, RuntimeDebug)]
+pub struct AccountData {
+	pub free: U256
+}
+
+pub trait Trait: system::Trait {
+	type Event: From<Event<Self, I>> + Into<<Self as system::Trait>::Event>;
+}
+
+decl_storage! {
+	trait Store for Module<T: Trait> as GenericAsset {
+		pub TotalIssuance: double_map hasher(blake2_128_concat) AssetId, hasher(blake2_128_concat) T::AccountId => U256;
+		pub Account:       double_map hasher(blake2_128_concat) AssetId, hasher(blake2_128_concat) T::AccountId => AccountData;
+	}
+}
+
+decl_event!(
+	pub enum Event<T>
+	where
+		AccountId = <T as system::Trait>::AccountId,
+	{
+		Burned(AssetId, AccountId, U256),
+		Minted(AssetId, AccountId, U256),
+	}
+);
+
+decl_error! {
+	pub enum Error for Module<T: Trait> {
+		/// Total issuance got overflowed after minting.
+		TotalMintingOverflow,
+		/// Free balance got overflowed after minting.
+		FreeMintingOverflow,
+		/// Total issuance got underflowed after burning.
+		TotalBurningUnderflow,
+		/// Free balance got underflowed after burning.
+		FreeBurningUnderflow,
+	}
+}
+
+decl_module! {
+
+	pub struct Module<T: Trait<I>, I: Instance> for enum Call where origin: T::Origin {
+
+		type Error = Error<T>;
+
+		fn deposit_event() = default;
+
+	}
+}
+
+impl<T: Trait> Module<T> {
+
+}

--- a/parachain/pallets/generic-asset/src/mock.rs
+++ b/parachain/pallets/generic-asset/src/mock.rs
@@ -15,14 +15,14 @@ impl_outer_origin! {
 	pub enum Origin for MockRuntime {}
 }
 
-mod test_events {
+mod generic_asset {
     pub use crate::Event;
 }
 
 impl_outer_event! {
     pub enum TestEvent for MockRuntime {
         system<T>,
-        test_events<T>,
+        generic_asset<T>,
     }
 }
 
@@ -51,7 +51,7 @@ impl system::Trait for MockRuntime {
 	type AccountId = AccountId;
 	type Lookup = IdentityLookup<Self::AccountId>;
 	type Header = Header;
-	type Event = ();
+	type Event = TestEvent;
 	type BlockHashCount = BlockHashCount;
 	type MaximumBlockWeight = MaximumBlockWeight;
 	type DbWeight = ();
@@ -67,19 +67,16 @@ impl system::Trait for MockRuntime {
 	type OnKilledAccount = ();
 }
 
-parameter_types! {
-	pub const ExistentialDeposit: u128 = 500;
-}
-
-
 impl Trait for MockRuntime {
-	type Event = ();
-	type Balance = u128;
+	type Event = TestEvent;
 }
 
-pub type PolkaERC20 = Module<MockRuntime>;
+pub type GenericAsset = Module<MockRuntime>;
+pub type System = system::Module<MockRuntime>;
 
 pub fn new_tester() -> sp_io::TestExternalities {
 	let storage = system::GenesisConfig::default().build_storage::<MockRuntime>().unwrap();
-	storage.into()
+	let mut ext: sp_io::TestExternalities = storage.into();
+	ext.execute_with(|| System::set_block_number(1));
+	ext
 }

--- a/parachain/pallets/generic-asset/src/mock.rs
+++ b/parachain/pallets/generic-asset/src/mock.rs
@@ -1,0 +1,85 @@
+// Mock runtime
+
+use super::*;
+
+use crate::{Module, Trait};
+use sp_core::H256;
+use frame_support::{impl_outer_origin, impl_outer_event, parameter_types, weights::Weight};
+use sp_runtime::{
+	traits::{BlakeTwo256, IdentityLookup, IdentifyAccount, Verify}, testing::Header, Perbill, MultiSignature
+};
+use sp_std::convert::{From};
+use frame_system as system;
+
+impl_outer_origin! {
+	pub enum Origin for MockRuntime {}
+}
+
+mod test_events {
+    pub use crate::Event;
+}
+
+impl_outer_event! {
+    pub enum TestEvent for MockRuntime {
+        system<T>,
+        test_events<T>,
+    }
+}
+
+pub type Signature = MultiSignature;
+
+pub type AccountId = <<Signature as Verify>::Signer as IdentifyAccount>::AccountId;
+
+#[derive(Clone, Eq, PartialEq)]
+pub struct MockRuntime;
+
+parameter_types! {
+	pub const BlockHashCount: u64 = 250;
+	pub const MaximumBlockWeight: Weight = 1024;
+	pub const MaximumBlockLength: u32 = 2 * 1024;
+	pub const AvailableBlockRatio: Perbill = Perbill::from_percent(75);
+}
+
+impl system::Trait for MockRuntime {
+	type BaseCallFilter = ();
+	type Origin = Origin;
+	type Call = ();
+	type Index = u64;
+	type BlockNumber = u64;
+	type Hash = H256;
+	type Hashing = BlakeTwo256;
+	type AccountId = AccountId;
+	type Lookup = IdentityLookup<Self::AccountId>;
+	type Header = Header;
+	type Event = ();
+	type BlockHashCount = BlockHashCount;
+	type MaximumBlockWeight = MaximumBlockWeight;
+	type DbWeight = ();
+	type BlockExecutionWeight = ();
+	type ExtrinsicBaseWeight = ();
+	type MaximumExtrinsicWeight = MaximumBlockWeight;
+	type MaximumBlockLength = MaximumBlockLength;
+	type AvailableBlockRatio = AvailableBlockRatio;
+	type Version = ();
+	type ModuleToIndex = ();
+	type AccountData = ();
+	type OnNewAccount = ();
+	type OnKilledAccount = ();
+}
+
+parameter_types! {
+	pub const ExistentialDeposit: u128 = 500;
+}
+
+
+impl Trait for MockRuntime {
+	type Event = ();
+	type Balance = u128;
+}
+
+pub type PolkaERC20 = Module<MockRuntime>;
+
+pub fn new_tester() -> sp_io::TestExternalities {
+	let storage = system::GenesisConfig::default().build_storage::<MockRuntime>().unwrap();
+	storage.into()
+}

--- a/parachain/pallets/generic-asset/src/tests.rs
+++ b/parachain/pallets/generic-asset/src/tests.rs
@@ -1,0 +1,49 @@
+use crate::{mock::*};
+use frame_support::{assert_ok};
+use sp_keyring::AccountKeyring as Keyring;
+use sp_core::H160;
+use frame_support::storage::StorageDoubleMap;
+use hex::FromHex;
+
+use artemis_ethereum::Event;
+use crate::FreeBalance;
+
+fn to_account_id(hexaddr: &str) -> [u8; 32] {
+	let mut buf: [u8; 32] = [0; 32];
+	let bytes: Vec<u8> = hexaddr.from_hex().unwrap();
+	buf.clone_from_slice(&bytes);
+	buf
+}
+
+#[test]
+fn it_mints() {
+	new_tester().execute_with(|| {
+		let token_addr = H160::zero();
+		let alice: AccountId = Keyring::Alice.into();
+		assert_ok!(PolkaERC20::do_mint(token_addr, &alice, 500));
+		assert_eq!(FreeBalance::<MockRuntime>::get(&token_addr, &alice), 500);
+
+		assert_ok!(PolkaERC20::do_mint(token_addr, &alice, 20));
+		assert_eq!(FreeBalance::<MockRuntime>::get(&token_addr, &alice), 520);
+	});
+}
+
+#[test]
+fn it_handles_ethereum_event() {
+	new_tester().execute_with(|| {
+		let token_addr = H160::zero();
+
+		let event = Event::SendERC20 {
+			sender: "cffeaaf7681c89285d65cfbe808b80e502696573".parse().unwrap(),
+			recipient: to_account_id("8eaf04151687736326c9fea17e25fc5287613693c912909cb226aa4794f26a48"),
+			token: token_addr,
+			amount: 10.into(),
+			nonce: 1
+		};
+
+		let bob: AccountId = Keyring::Bob.into();
+
+		assert_ok!(PolkaERC20::handle_event(event));
+		assert_eq!(FreeBalance::<MockRuntime>::get(&token_addr, &bob), 10);
+	});
+}

--- a/parachain/pallets/polkaerc20-app/Cargo.toml
+++ b/parachain/pallets/polkaerc20-app/Cargo.toml
@@ -72,6 +72,14 @@ path = "../../primitives/core"
 default-features = false
 path = "../../primitives/ethereum"
 
+[dependencies.artemis-generic-asset]
+default-features = false
+path = "../../pallets/generic-asset"
+
+[dependencies.pallet-bridge]
+default-features = false
+path = "../../pallets/bridge"
+
 [features]
 default = ['std']
 std = [

--- a/parachain/pallets/polkaerc20-app/src/lib.rs
+++ b/parachain/pallets/polkaerc20-app/src/lib.rs
@@ -3,21 +3,18 @@
 /// Implementation for PolkaERC20 token assets
 ///
 use sp_std::prelude::*;
-use sp_std::{fmt::Debug, convert::TryInto};
-use sp_core::H160;
-use sp_runtime::traits::{
-	CheckedAdd, MaybeSerializeDeserialize, Member,  AtLeast32BitUnsigned};
-use frame_system::{self as system};
+use sp_core::{H160, U256, RuntimeDebug};
+use frame_system::{self as system, ensure_signed};
 use frame_support::{
-	decl_error, decl_event, decl_module, decl_storage, Parameter,
+	decl_error, decl_event, decl_module, decl_storage,
 	dispatch::{DispatchResult, DispatchError},
-	storage::StorageDoubleMap
 };
 
-use codec::{Decode};
+use codec::{Encode, Decode};
 
-use artemis_core::{AppID, Application, Message};
+use artemis_core::{AppID, Application, RelayEventEmitter, Message};
 use artemis_ethereum::{self as ethereum, SignedMessage};
+use artemis_generic_asset as generic_asset;
 
 #[cfg(test)]
 mod mock;
@@ -25,38 +22,28 @@ mod mock;
 #[cfg(test)]
 mod tests;
 
-pub trait Trait: system::Trait {
-	type Event: From<Event<Self>> + Into<<Self as system::Trait>::Event>;
+pub const APP_ID: &[u8; 32] = &[1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
 
-	type Balance: Parameter + Member + AtLeast32BitUnsigned + Default + Copy + Debug + MaybeSerializeDeserialize;
+#[derive(Encode, Decode, Clone, PartialEq, Eq, RuntimeDebug)]
+pub enum RelayEvent<AccountId> {
+	Burned(H160, AccountId, U256)
+}
+
+pub trait Trait: system::Trait + generic_asset::Trait {
+	type Event: From<Event> + Into<<Self as system::Trait>::Event>;
+	type Bridge: RelayEventEmitter<RelayEvent<Self::AccountId>>;
 }
 
 decl_storage! {
-	trait Store for Module<T: Trait> as PolkaERC20Map {
-		// Free balances are represent as a doublemap: (TokenAddr, AccountId) -> Balance
-		//
-		// The choice of hashers was influenced by pallet-generic-asset, where free balances
-		// are also represented using a StorageDouble with twox_64_concat and blake2_128_concat
-		// hashers. So I'm assuming its a safe choice.
-		pub FreeBalance: double_map hasher(twox_64_concat) H160, hasher(blake2_128_concat) T::AccountId => T::Balance;
-	}
+	trait Store for Module<T: Trait> as Erc20Module {}
 }
 
 decl_event!(
-	pub enum Event<T>
-	where
-		AccountId = <T as system::Trait>::AccountId,
-		BalanceERC20 = <T as Trait>::Balance,
-	{
-		Minted(H160, AccountId, BalanceERC20),
-	}
+	pub enum Event {}
 );
 
 decl_error! {
-	pub enum Error for Module<T: Trait> {
-		/// Free balance got overflowed after minting.
-		FreeMintingOverflow,
-	}
+	pub enum Error for Module<T: Trait> {}
 }
 
 decl_module! {
@@ -67,6 +54,14 @@ decl_module! {
 
 		fn deposit_event() = default;
 
+		#[weight = 0]
+		pub fn burn(origin, token_id: H160, amount: U256) -> DispatchResult {
+			let who = ensure_signed(origin)?;
+			<generic_asset::Module<T>>::do_burn(token_id, &who, amount)?;
+			T::Bridge::emit(APP_ID, RelayEvent::<T::AccountId>::Burned(token_id, who, amount));
+			Ok(())
+		}
+
 	}
 }
 
@@ -76,35 +71,21 @@ impl<T: Trait> Module<T> {
 		T::AccountId::decode(&mut &data[..]).ok()
 	}
 
-	fn u128_to_balance(input: u128) -> Option<T::Balance>  {
-		input.try_into().ok()
-	}
-
-	fn do_mint(token_addr: H160, to: &T::AccountId, amount: T::Balance) -> DispatchResult {
-		let original_free_balance = <FreeBalance<T>>::get(&token_addr, to);
-		let value = original_free_balance.checked_add(&amount)
-			.ok_or(Error::<T>::FreeMintingOverflow)?;
-		<FreeBalance<T>>::insert(&token_addr, to, value);
-		Self::deposit_event(RawEvent::Minted(token_addr, to.clone(), amount));
-		Ok(())
-	}
-
 	fn handle_event(event: ethereum::Event) -> DispatchResult {
+
 		match event {
 			ethereum::Event::SendERC20 { recipient, token, amount, ..} => {
+				if token.is_zero() {
+					return Err(DispatchError::Other("Invalid token address"))	
+				}
 				let account = match Self::bytes_to_account_id(&recipient) {
 					Some(account) => account,
 					None => {
 						return Err(DispatchError::Other("Invalid sender account"))
 					}
 				};
-				let balance = match Self::u128_to_balance(amount.as_u128()) {
-					Some(balance) => balance,
-					None => {
-						return Err(DispatchError::Other("Invalid amount"))
-					}
-				};
-				Self::do_mint(token, &account, balance)
+				<generic_asset::Module<T>>::do_mint(token, &account, amount)?;
+				Ok(())
 			}
 			_ => {
 				// Ignore all other ethereum events. In the next milestone the

--- a/parachain/pallets/polkaeth-app/Cargo.toml
+++ b/parachain/pallets/polkaeth-app/Cargo.toml
@@ -72,6 +72,13 @@ path = "../../primitives/core"
 default-features = false
 path = "../../primitives/ethereum"
 
+[dependencies.artemis-generic-asset]
+default-features = false
+path = "../../pallets/generic-asset"
+
+[dependencies.pallet-bridge]
+default-features = false
+path = "../../pallets/bridge"
 
 [dependencies.balances]
 default-features = false

--- a/parachain/pallets/polkaeth-app/src/lib.rs
+++ b/parachain/pallets/polkaeth-app/src/lib.rs
@@ -6,15 +6,15 @@ use frame_system::{self as system, ensure_signed};
 use frame_support::{
 	decl_error, decl_event, decl_module, decl_storage,
 	dispatch::{DispatchResult, DispatchError},
-	traits::{Currency, ExistenceRequirement, WithdrawReason, WithdrawReasons},
 };
 use sp_std::prelude::*;
-use artemis_core::{AppID, Application, Message};
-use codec::Decode;
+use sp_core::{H160, U256, RuntimeDebug};
 
-use sp_std::convert::TryInto;
+use artemis_core::{AppID, Application, RelayEventEmitter, Message};
+use codec::{Encode, Decode};
 
 use artemis_ethereum::{self as ethereum, SignedMessage};
+use artemis_generic_asset as generic_asset;
 
 #[cfg(test)]
 mod mock;
@@ -22,41 +22,28 @@ mod mock;
 #[cfg(test)]
 mod tests;
 
-pub type PolkaETH<T> =
-	<<T as Trait>::Currency as Currency<<T as system::Trait>::AccountId>>::Balance;
+pub const APP_ID: &[u8; 32] = &[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
 
-pub trait Trait: system::Trait {
-	type Event: From<Event<Self>> + Into<<Self as system::Trait>::Event>;
+#[derive(Encode, Decode, Clone, PartialEq, Eq, RuntimeDebug)]
+pub enum RelayEvent<AccountId> {
+	Burned(AccountId, U256)
+}
 
-	type Currency: Currency<Self::AccountId>;
+pub trait Trait: system::Trait + generic_asset::Trait {
+	type Event: From<Event> + Into<<Self as system::Trait>::Event>;
+	type Bridge: RelayEventEmitter<RelayEvent<Self::AccountId>>;
 }
 
 decl_storage! {
-	trait Store for Module<T: Trait> as PolkaETHModule {
-
-	}
-	add_extra_genesis {
-		config(dummy): bool;
-		build(|_| {});
-	}
+	trait Store for Module<T: Trait> as Erc20Module {}
 }
 
 decl_event!(
-	pub enum Event<T>
-	where
-		AccountId = <T as system::Trait>::AccountId,
-		PolkaETH = PolkaETH<T>,
-	{
-		Minted(AccountId, PolkaETH),
-		Burned(AccountId, PolkaETH),
-		Transfer(AccountId, AccountId, PolkaETH),
-	}
+	pub enum Event {}
 );
 
 decl_error! {
-	pub enum Error for Module<T: Trait> {
-
-	}
+	pub enum Error for Module<T: Trait> {}
 }
 
 decl_module! {
@@ -67,42 +54,11 @@ decl_module! {
 
 		fn deposit_event() = default;
 
-		#[weight = 10_000]
-		fn transfer(origin, to: T::AccountId, amount: PolkaETH<T>, allow_death: bool) -> DispatchResult {
+		#[weight = 0]
+		pub fn burn(origin, amount: U256) -> DispatchResult {
 			let who = ensure_signed(origin)?;
-
-			let er = match allow_death {
-				true => ExistenceRequirement::AllowDeath,
-				false => ExistenceRequirement::KeepAlive,
-			};
-
-			T::Currency::transfer(&who, &to, amount, er)?;
-
-			Self::deposit_event(RawEvent::Transfer(who, to, amount));
-			Ok(())
-		}
-
-		///
-		/// To initiate a transfer of PolkaETH to ETH, account holders must burn PolkaETH.
-		///
-		#[weight = 10_000]
-		fn burn(origin, amount: PolkaETH<T>, allow_death: bool) -> DispatchResult {
-			// TODO: verify origin
-			let who = ensure_signed(origin)?;
-
-			// TODO: Add our own reason, the existing ones don't seem to match our needs.
-			let mut reasons = WithdrawReasons::none();
-			reasons.set(WithdrawReason::Transfer);
-
-			let er = match allow_death {
-				true => ExistenceRequirement::AllowDeath,
-				false => ExistenceRequirement::KeepAlive,
-			};
-
-			let _ = T::Currency::withdraw(&who, amount, reasons, er)?;
-
-			Self::deposit_event(RawEvent::Burned(who, amount));
-
+			<generic_asset::Module<T>>::do_burn(H160::zero(), &who, amount)?;
+			T::Bridge::emit(APP_ID, RelayEvent::<T::AccountId>::Burned(who, amount));
 			Ok(())
 		}
 
@@ -115,16 +71,6 @@ impl<T: Trait> Module<T> {
 		T::AccountId::decode(&mut &data[..]).ok()
 	}
 
-	fn u128_to_balance(input: u128) -> Option<PolkaETH<T>>  {
-		input.try_into().ok()
-	}
-
-	/// The parachain will mint PolkaETH for users who have locked up ETH in a bridge smart contract.
-	fn do_mint(to: T::AccountId,  amount: PolkaETH<T>) {
-		let _ = T::Currency::deposit_creating(&to, amount);
-		Self::deposit_event(RawEvent::Minted(to, amount));
-	}
-
 	fn handle_event(event: ethereum::Event) -> DispatchResult {
 		match event {
 			ethereum::Event::SendETH { recipient, amount, ..} => {
@@ -134,13 +80,7 @@ impl<T: Trait> Module<T> {
 						return Err(DispatchError::Other("Invalid sender account"))
 					}
 				};
-				let balance = match Self::u128_to_balance(amount.as_u128()) {
-					Some(balance) => balance,
-					None => {
-						return Err(DispatchError::Other("Invalid amount"))
-					}
-				};
-				Self::do_mint(account, balance);
+				<generic_asset::Module<T>>::do_mint(H160::zero(), &account, amount)?;
 				Ok(())
 			}
 			_ => {

--- a/parachain/primitives/core/Cargo.toml
+++ b/parachain/primitives/core/Cargo.toml
@@ -22,10 +22,17 @@ git = 'https://github.com/paritytech/substrate.git'
 tag = 'v2.0.0-rc4'
 version = '2.0.0-rc4'
 
+[dependencies.sp-core]
+default-features = false
+git = 'https://github.com/paritytech/substrate.git'
+tag = 'v2.0.0-rc4'
+version = '2.0.0-rc4'
+
 [features]
 default = ['std']
 std = [
     'frame-support/std',
     'sp-std/std',
+    'sp-core/std',
     'codec/std'
 ]

--- a/parachain/primitives/core/src/lib.rs
+++ b/parachain/primitives/core/src/lib.rs
@@ -4,6 +4,7 @@
 
 //use sp_std::prelude::*;
 use frame_support::dispatch::DispatchResult;
+use codec::Encode;
 
 pub mod types;
 pub mod registry;
@@ -12,10 +13,9 @@ pub use types::{AppID, Message};
 
 
 /// The bridge module implements this trait
-pub trait Bridge {
+pub trait RelayEventEmitter<K> where K: Encode {
 
-	// just a dummy stand-in until we flesh out this trait some more
-	fn dummy();
+	fn emit(app_id: &AppID, data: K);
 
 }
 

--- a/parachain/runtime/Cargo.toml
+++ b/parachain/runtime/Cargo.toml
@@ -40,8 +40,9 @@ std = [
     'bridge/std',
     'broker/std',
     'dummy-verifier/std',
-    'polkaeth-app/std',
-    'polkaerc20-app/std',
+    'generic-asset/std',
+    'eth-app/std',
+    'erc20-app/std',
 ]
 
 [dependencies.aura]
@@ -228,13 +229,19 @@ package = 'pallet-dummy-verifier'
 path = '../pallets/dummy-verifier'
 version = '0.1.1'
 
-[dependencies.polkaeth-app]
+[dependencies.generic-asset]
+default-features = false
+package = 'artemis-generic-asset'
+path = '../pallets/generic-asset'
+version = '0.1.1'
+
+[dependencies.eth-app]
 default-features = false
 package = 'polkaeth-app'
 path = '../pallets/polkaeth-app'
 version = '0.1.1'
 
-[dependencies.polkaerc20-app]
+[dependencies.erc20-app]
 default-features = false
 package = 'polkaerc20-app'
 path = '../pallets/polkaerc20-app'

--- a/parachain/runtime/src/lib.rs
+++ b/parachain/runtime/src/lib.rs
@@ -286,29 +286,16 @@ impl dummy_verifier::Trait for Runtime {
 	type Scheduler = scheduler::Module<Runtime>;
 }
 
-impl balances::Trait<balances::Instance2> for Runtime {
-	type Balance = u128; // We'll need to use a BigNum (U256) for PolkaETH
+impl generic_asset::Trait for Runtime {
 	type Event = Event;
-	type DustRemoval = ();
-	type ExistentialDeposit = ExistentialDeposit;
-	type AccountStore = StorageMapShim<
-		balances::Account<Runtime, balances::Instance2>,
-		system::CallOnCreatedAccount<Runtime>,
-		system::CallKillAccount<Runtime>,
-		AccountId,
-		balances::AccountData<Balance>,
-	>;
-
 }
 
-impl polkaeth_app::Trait for Runtime {
+impl eth_app::Trait for Runtime {
 	type Event = Event;
-	type Currency = balances::Module<Runtime, balances::Instance2>;
 }
 
-impl polkaerc20_app::Trait for Runtime {
+impl erc20_app::Trait for Runtime {
 	type Event = Event;
-	type Balance = u128;
 }
 
 construct_runtime!(
@@ -323,15 +310,15 @@ construct_runtime!(
 		Aura: aura::{Module, Config<T>, Inherent(Timestamp)},
 		Grandpa: grandpa::{Module, Call, Storage, Config, Event},
 		Balances: balances::{Module, Call, Storage, Config<T>, Event<T>},
-		BalancesPolkaETH: balances::<Instance2>::{Module, Call, Storage, Config<T>, Event<T>},
 		TransactionPayment: transaction_payment::{Module, Storage},
 		Sudo: sudo::{Module, Call, Config<T>, Storage, Event<T>},
 		Scheduler: scheduler::{Module, Call, Storage, Event<T>},
 		Bridge: bridge::{Module, Call, Storage, Event<T>},
 		Broker: broker::{Module, Call, Storage, Event},
 		DummyVerifier: dummy_verifier::{Module, Call, Storage, Event},
-		AppPolkaETH: polkaeth_app::{Module, Call, Storage, Event<T>},
-		AppPolkaERC20: polkaerc20_app::{Module, Call, Storage, Event<T>},
+		GenericAsset: generic_asset::{Module, Call, Storage, Event<T>}
+		ETH: polkaeth_app::{Module, Call, Storage, Event},
+		ERC20: polkaerc20_app::{Module, Call, Storage, Event},
 	}
 );
 

--- a/parachain/runtime/src/lib.rs
+++ b/parachain/runtime/src/lib.rs
@@ -7,7 +7,6 @@
 #[cfg(feature = "std")]
 include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 
-use frame_support::traits::StorageMapShim;
 use sp_core::{crypto::KeyTypeId, OpaqueMetadata};
 use sp_runtime::{
 	ApplyExtrinsicResult, generic, create_runtime_str, impl_opaque_keys, MultiSignature,
@@ -275,8 +274,8 @@ impl broker::Trait for Runtime {
 	type Event = Event;
 
 	type DummyVerifier = dummy_verifier::Module<Runtime>;
-	type PolkaETH = polkaeth_app::Module<Runtime>;
-	type PolkaERC20 = polkaerc20_app::Module<Runtime>;
+	type AppETH = eth_app::Module<Runtime>;
+	type AppERC20 = erc20_app::Module<Runtime>;
 }
 
 impl dummy_verifier::Trait for Runtime {
@@ -292,10 +291,12 @@ impl generic_asset::Trait for Runtime {
 
 impl eth_app::Trait for Runtime {
 	type Event = Event;
+	type Bridge = bridge::Module<Runtime>;
 }
 
 impl erc20_app::Trait for Runtime {
 	type Event = Event;
+	type Bridge = bridge::Module<Runtime>;
 }
 
 construct_runtime!(
@@ -316,9 +317,9 @@ construct_runtime!(
 		Bridge: bridge::{Module, Call, Storage, Event<T>},
 		Broker: broker::{Module, Call, Storage, Event},
 		DummyVerifier: dummy_verifier::{Module, Call, Storage, Event},
-		GenericAsset: generic_asset::{Module, Call, Storage, Event<T>}
-		ETH: polkaeth_app::{Module, Call, Storage, Event},
-		ERC20: polkaerc20_app::{Module, Call, Storage, Event},
+		GenericAsset: generic_asset::{Module, Call, Storage, Event<T>},
+		ETH: eth_app::{Module, Call, Storage, Event},
+		ERC20: erc20_app::{Module, Call, Storage, Event},
 	}
 );
 


### PR DESCRIPTION
These changes implement the following requirements for Milestone 4:
1. Burning of assets
2. Relaying of application events in a suitable form for the bridge relayer and ethereum smart contracts.

To align the implementations of the PolkaETH and PolkaERC20 applications, and share common behavior, I've introduced a new pallet `generic_asset`. It stores U256 balances for arbitrary assets identified by a `H160` hash.

Closes #18 