### PR TITLE
Add attribution for keybase code

### DIFF
--- a/bridgerelayer/keybase/ethereum/keypair.go
+++ b/bridgerelayer/keybase/ethereum/keypair.go
@@ -1,3 +1,6 @@
+// Copyright 2020 ChainSafe Systems
+// SPDX-License-Identifier: LGPL-3.0-only
+
 package ethereum
 
 import (

--- a/bridgerelayer/keybase/keypair.go
+++ b/bridgerelayer/keybase/keypair.go
@@ -16,6 +16,7 @@ Types
 A general overview on the secp256k1 can be found here: https://en.bitcoin.it/wiki/Secp256k1
 A general overview on the sr25519 type can be found here: https://wiki.polkadot.network/docs/en/learn-cryptography
 */
+
 package keybase
 
 type KeyType = string

--- a/bridgerelayer/keybase/keypair.go
+++ b/bridgerelayer/keybase/keypair.go
@@ -1,3 +1,21 @@
+// Copyright 2020 ChainSafe Systems
+// SPDX-License-Identifier: LGPL-3.0-only
+
+/*
+The crypto package is used to provide functionality to several keypair types.
+The current supported types are secp256k1 and sr25519.
+
+Keypairs
+
+The keypair interface is used to bridge the different types of crypto formats.
+Every Keypair has both a Encode and Decode function that allows writing and reading from keystore files.
+There is also the Address and PublicKey functions that allow access to public facing fields.
+
+Types
+
+A general overview on the secp256k1 can be found here: https://en.bitcoin.it/wiki/Secp256k1
+A general overview on the sr25519 type can be found here: https://wiki.polkadot.network/docs/en/learn-cryptography
+*/
 package keybase
 
 type KeyType = string

--- a/bridgerelayer/keybase/substrate/keypair.go
+++ b/bridgerelayer/keybase/substrate/keypair.go
@@ -1,11 +1,14 @@
+// Copyright 2020 ChainSafe Systems
+// SPDX-License-Identifier: LGPL-3.0-only
+
 package substrate
 
 import (
 	"crypto/rand"
 
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/snowfork/go-substrate-rpc-client/signature"
 	"github.com/snowfork/go-substrate-rpc-client/types"
-	"github.com/ethereum/go-ethereum/common/hexutil"
 
 	"github.com/snowfork/polkadot-ethereum/bridgerelayer/keybase"
 )


### PR DESCRIPTION
The keybase module is heavily influenced by ChainSafe's ChainBridge keypair code. This PR adds attribution in the form of copyright information copied directly from the original source to the relevant files. The library is licensed under [LGPL-3.0-only](https://spdx.org/licenses/LGPL-3.0-only.html), meaning that it can be used commercially and does not need to be distributed under the LGPL-3.0-only license.

Copying the copyright/license directly may not be the best approach here, should we remove/add to some of the attribution sections?