### PR TITLE
Fix segfault in relayer

### DIFF
--- a/bridgerelayer/chains/substrate/events.go
+++ b/bridgerelayer/chains/substrate/events.go
@@ -4,81 +4,62 @@ import (
 	"github.com/snowfork/go-substrate-rpc-client/types"
 )
 
-type EventSchedulerScheduled struct {
-	Phase		types.Phase
-	BlockNumber types.BlockNumber
-	Index       types.U32
-	Topics    	[]types.Hash
-}
-
-type EventSchedulerDispatched struct {
-	Phase		types.Phase
-	BlockNumber types.BlockNumber
-	Index       types.U32
-	MaybeID     types.OptionBytes8
-	Result      types.DispatchResult
-	Topics    	[]types.Hash
-}
-
 type EventBridgeReceived struct {
-	Phase		types.Phase
-	AccountID  	types.AccountID
-	AppID       [32]byte
-	Hash        types.H256
-	Topics    	[]types.Hash
+	Phase     types.Phase
+	AccountID types.AccountID
+	AppID     [32]byte
+	Hash      types.H256
+	Topics    []types.Hash
 }
 
 type EventAssetBurned struct {
-	Phase		types.Phase
-	AssetID     types.H160
-	AccountID  	types.AccountID
-	Amount      types.U256
-	Topics    	[]types.Hash
+	Phase     types.Phase
+	AssetID   types.H160
+	AccountID types.AccountID
+	Amount    types.U256
+	Topics    []types.Hash
 }
 
 type EventAssetMinted struct {
-	Phase		types.Phase
-	AssetID     types.H160
-	AccountID  	types.AccountID
-	Amount      types.U256
-	Topics    	[]types.Hash
+	Phase     types.Phase
+	AssetID   types.H160
+	AccountID types.AccountID
+	Amount    types.U256
+	Topics    []types.Hash
 }
 
 type EventAssetTransferred struct {
-	Phase		types.Phase
-	AssetID     types.H160
-	Sender  	types.AccountID
-	Receiver  	types.AccountID
-	Amount      types.U256
-	Topics    	[]types.Hash
+	Phase    types.Phase
+	AssetID  types.H160
+	Sender   types.AccountID
+	Receiver types.AccountID
+	Amount   types.U256
+	Topics   []types.Hash
 }
 
 type EventErc20Transfer struct {
-	Phase		types.Phase
-	TokenID    	types.H160
-	AccountID  	types.AccountID
-	Recipient   types.H160
-	Amount		types.U256
-	Topics    	[]types.Hash
+	Phase     types.Phase
+	TokenID   types.H160
+	AccountID types.AccountID
+	Recipient types.H160
+	Amount    types.U256
+	Topics    []types.Hash
 }
 
 type EventEthTransfer struct {
-	Phase		types.Phase
-	AccountID  	types.AccountID
-	Recipient   types.H160
-	Amount		types.U256
-	Topics    	[]types.Hash
+	Phase     types.Phase
+	AccountID types.AccountID
+	Recipient types.H160
+	Amount    types.U256
+	Topics    []types.Hash
 }
 
 type Events struct {
 	types.EventRecords
-	Scheduler_Scheduled		[]EventSchedulerScheduled	//revive:disable-line
-	Scheduler_Dispatched	[]EventSchedulerDispatched	//revive:disable-line
-	Bridge_Received			[]EventBridgeReceived	//revive:disable-line
-	Asset_Burned			[]EventAssetBurned		//revive:disable-line
-	Asset_Minted			[]EventAssetMinted		//revive:disable-line
-	Asset_Transferred		[]EventAssetTransferred	//revive:disable-line
-	ETH_Transfer			[]EventEthTransfer		//revive:disable-line
-	ERC20_Transfer			[]EventErc20Transfer	//revive:disable-line
+	Bridge_Received   []EventBridgeReceived   //revive:disable-line
+	Asset_Burned      []EventAssetBurned      //revive:disable-line
+	Asset_Minted      []EventAssetMinted      //revive:disable-line
+	Asset_Transferred []EventAssetTransferred //revive:disable-line
+	ETH_Transfer      []EventEthTransfer      //revive:disable-line
+	ERC20_Transfer    []EventErc20Transfer    //revive:disable-line
 }
-

--- a/parachain/pallets/dummy-verifier/src/lib.rs
+++ b/parachain/pallets/dummy-verifier/src/lib.rs
@@ -53,11 +53,12 @@ decl_module! {
 impl<T: Trait> Module<T> {
 
 	// No-op verifier that sends verified message back to broker.
-	fn schedule_approval(app_id: AppID, message: Message) -> DispatchResult {
+	fn do_verify(app_id: AppID, message: Message) -> DispatchResult {
 
 		let call: Box<<T as Trait>::Call> = Box::new(broker::Call::accept(app_id, message).into());
 
-		// we purposely swallow the error here
+		// we purposely swallow the result/error since the *dummy* verifier has a fire and forget
+		// approach when submitting messages back to the broker.
 		let _ = call.dispatch(RawOrigin::Root.into());
 
 		Ok(())
@@ -70,7 +71,7 @@ impl<T: Trait> Verifier for Module<T> {
 	// verify a message
 	fn verify(app_id: AppID, message: Message) -> DispatchResult {
 
-		Self::schedule_approval(app_id, message)?;
+		Self::do_verify(app_id, message)?;
 
 		Ok(())
 	}

--- a/parachain/pallets/dummy-verifier/src/lib.rs
+++ b/parachain/pallets/dummy-verifier/src/lib.rs
@@ -57,7 +57,8 @@ impl<T: Trait> Module<T> {
 
 		let call: Box<<T as Trait>::Call> = Box::new(broker::Call::accept(app_id, message).into());
 
-		let _ = call.dispatch(RawOrigin::Root.into()).map(|_| ()).map_err(|e| e.error);
+		// we purposely swallow the error here
+		let _ = call.dispatch(RawOrigin::Root.into());
 
 		Ok(())
 	}

--- a/parachain/pallets/dummy-verifier/src/lib.rs
+++ b/parachain/pallets/dummy-verifier/src/lib.rs
@@ -57,7 +57,9 @@ impl<T: Trait> Module<T> {
 
 		let call: Box<<T as Trait>::Call> = Box::new(broker::Call::accept(app_id, message).into());
 
-		call.dispatch(RawOrigin::Root.into()).map(|_| ()).map_err(|e| e.error)
+		let _ = call.dispatch(RawOrigin::Root.into()).map(|_| ()).map_err(|e| e.error);
+
+		Ok(())
 	}
 
 }

--- a/parachain/runtime/src/lib.rs
+++ b/parachain/runtime/src/lib.rs
@@ -281,8 +281,7 @@ impl broker::Trait for Runtime {
 impl dummy_verifier::Trait for Runtime {
 	type Event = Event;
 
-	type Proposal = Call;
-	type Scheduler = scheduler::Module<Runtime>;
+	type Call = Call;
 }
 
 impl asset::Trait for Runtime {


### PR DESCRIPTION
The fix was to make the dummy verifier not use the `scheduler` pallet for submitting the message back to the broker. This ensures that the scheduler events are not emitted from the parachain. The relayer was unable to read these events properly.