### PR TITLE
Security fix: restrict application message handling to Bridge contract

### DIFF
--- a/ethereum/contracts/Application.sol
+++ b/ethereum/contracts/Application.sol
@@ -4,4 +4,6 @@ pragma solidity >=0.6.2;
 // Application contains methods that all applications must implement
 abstract contract Application {
     function handle(bytes memory _data) public virtual;
+
+    function register(address _bridge) public virtual returns(bool);
 }

--- a/ethereum/contracts/Application.sol
+++ b/ethereum/contracts/Application.sol
@@ -3,7 +3,13 @@ pragma solidity >=0.6.2;
 
 // Application contains methods that all applications must implement
 abstract contract Application {
+    /**
+     * @dev Handles a SCALE encoded message from the Bridge
+     */
     function handle(bytes memory _data) public virtual;
 
+    /**
+     * @dev Registers the Bridge contract on the application
+     */
     function register(address _bridge) public virtual returns(bool);
 }

--- a/ethereum/contracts/Application.sol
+++ b/ethereum/contracts/Application.sol
@@ -11,5 +11,5 @@ abstract contract Application {
     /**
      * @dev Registers the Bridge contract on the application
      */
-    function register(address _bridge) public virtual returns(bool);
+    function register(address _bridge) public virtual;
 }

--- a/ethereum/contracts/Bridge.sol
+++ b/ethereum/contracts/Bridge.sol
@@ -18,9 +18,7 @@ contract Bridge {
     constructor(address _verfierAddr, address[] memory _apps) public {
         verifier = Verifier(_verfierAddr);
         for(uint256 i = 0; i < _apps.length; i++) {
-            if(verifyApp(_apps[i])) {
-                applications[_apps[i]] = true;
-            }
+            registerApp(_apps[i]);
         }
     }
 
@@ -46,13 +44,11 @@ contract Bridge {
     }
 
     /**
-     * @dev verifies new applications
-     * @param _appID address _appID is the application's contract address to be verified
+     * @dev registers a new application onto the bridge
+     * @param _appID address _appID is the application's contract address to be registered
      */
-    function verifyApp(address _appID)
+    function registerApp(address _appID)
         internal
-        view
-        returns(bool)
     {
         require(!applications[_appID], "Application is already registered");
 
@@ -61,6 +57,8 @@ contract Bridge {
         require(codehash != 0x0, "There's no account for this address on the network");
         require(codehash != NON_CONTRACT_ACCOUNT_HASH, "Only contract accounts can be registered as applications");
 
-        return true;
+        Application app = Application(_appID);
+        require(app.register(address(this)), "Application failed registration");
+        applications[_appID] = true;
     }
 }

--- a/ethereum/contracts/Bridge.sol
+++ b/ethereum/contracts/Bridge.sol
@@ -58,7 +58,7 @@ contract Bridge {
         require(codehash != NON_CONTRACT_ACCOUNT_HASH, "Only contract accounts can be registered as applications");
 
         Application app = Application(_appID);
-        require(app.register(address(this)), "Application failed registration");
+        app.register(address(this));
         applications[_appID] = true;
     }
 }

--- a/ethereum/contracts/ERC20App.sol
+++ b/ethereum/contracts/ERC20App.sol
@@ -12,10 +12,17 @@ contract ERC20App is Application {
 
     uint64 constant PAYLOAD_LENGTH = 104;
 
+    address public bridge;
     mapping(address => uint256) public totalTokens;
 
     event AppTransfer(address _sender, bytes32 _recipient, address _token, uint256 _amount);
     event Unlock(bytes _sender, address _recipient, address _token, uint256 _amount);
+
+    function register(address _bridge) public override returns(bool) {
+        require(bridge == address(0), "Bridge has already been registered");
+        bridge = _bridge;
+        return true;
+    }
 
     function sendERC20(bytes32 _recipient, address _tokenAddr, uint256 _amount)
         public
@@ -35,6 +42,7 @@ contract ERC20App is Application {
         public
         override
     {
+        require(msg.sender == bridge);
         require(_data.length >= PAYLOAD_LENGTH, "Invalid Payload");
 
         // Decode sender bytes
@@ -56,7 +64,7 @@ contract ERC20App is Application {
         internal
     {
         require(_amount > 0, "Must unlock a positive amount");
-        require(totalTokens[_token] > _amount, "ERC20 token balances insufficient to fulfill the unlock request");
+        require(_amount <= totalTokens[_token], "ERC20 token balances insufficient to fulfill the unlock request");
 
         totalTokens[_token] = totalTokens[_token].sub(_amount);
         require(IERC20(_token).transfer(_recipient, _amount), "ERC20 token transfer failed");

--- a/ethereum/contracts/ERC20App.sol
+++ b/ethereum/contracts/ERC20App.sol
@@ -18,10 +18,9 @@ contract ERC20App is Application {
     event AppTransfer(address _sender, bytes32 _recipient, address _token, uint256 _amount);
     event Unlock(bytes _sender, address _recipient, address _token, uint256 _amount);
 
-    function register(address _bridge) public override returns(bool) {
+    function register(address _bridge) public override {
         require(bridge == address(0), "Bridge has already been registered");
         bridge = _bridge;
-        return true;
     }
 
     function sendERC20(bytes32 _recipient, address _tokenAddr, uint256 _amount)

--- a/ethereum/contracts/ETHApp.sol
+++ b/ethereum/contracts/ETHApp.sol
@@ -11,6 +11,7 @@ contract ETHApp is Application {
 
     uint64 constant PAYLOAD_LENGTH = 84;
 
+    address public bridge;
     uint256 public totalETH;
 
     event AppTransfer(address _sender, bytes32 _recipient, uint256 _amount);
@@ -18,6 +19,12 @@ contract ETHApp is Application {
 
     constructor() public {
         totalETH = 0;
+    }
+
+    function register(address _bridge) public override returns(bool) {
+        require(bridge == address(0), "Bridge has already been registered");
+        bridge = _bridge;
+        return true;
     }
 
     function sendETH(bytes32 _recipient)
@@ -36,6 +43,7 @@ contract ETHApp is Application {
         public
         override
     {
+        require(msg.sender == bridge);
         require(_data.length >= PAYLOAD_LENGTH, "Invalid payload");
 
         // Decode sender bytes

--- a/ethereum/contracts/ETHApp.sol
+++ b/ethereum/contracts/ETHApp.sol
@@ -21,10 +21,9 @@ contract ETHApp is Application {
         totalETH = 0;
     }
 
-    function register(address _bridge) public override returns(bool) {
+    function register(address _bridge) public override {
         require(bridge == address(0), "Bridge has already been registered");
         bridge = _bridge;
-        return true;
     }
 
     function sendETH(bytes32 _recipient)

--- a/ethereum/package.json
+++ b/ethereum/package.json
@@ -11,11 +11,12 @@
     "dotenv": "^8.2.0",
     "find-config": "^1.0.0",
     "solc": "^0.6.12",
+    "solidity-docgen": "^0.5.6",
     "temp": "^0.9.1",
     "truffle": "^5.1.32",
     "unique-filename": "^1.1.1",
     "web3": "^1.2.9",
-    "web3-utils": "^1.2.9"
+    "web3-utils": "^1.3.0"
   },
   "devDependencies": {
     "@babel/core": "^7.11.6"

--- a/ethereum/test/test_erc20_app.js
+++ b/ethereum/test/test_erc20_app.js
@@ -25,9 +25,6 @@ contract("ERC20App", function (accounts) {
 
     it("should deploy and initialize the ERC20App contract", async function () {
       this.erc20App.should.exist;
-
-      const nonce = Number(await this.erc20App.nonce());
-      nonce.should.be.bignumber.equal(0);
     });
   });
 
@@ -50,7 +47,6 @@ contract("ERC20App", function (accounts) {
     it("should support ERC20 deposits", async function () {
       // Load initial state
       const beforeTotalERC20 = Number(await this.erc20App.totalTokens(this.token.address));
-      const beforeNonce = Number(await this.erc20App.nonce());
       const beforeTestTokenBalance = Number(await this.token.balanceOf(this.erc20App.address));
       const beforeUserBalance = Number(await this.token.balanceOf(userOne));
 
@@ -97,10 +93,6 @@ contract("ERC20App", function (accounts) {
       // Confirm contract's locked ERC20 counter has increased by amount locked
       const afterTotalERC20 = await this.erc20App.totalTokens(this.token.address);
       Number(afterTotalERC20).should.be.bignumber.equal(beforeTotalERC20+amount);
-
-      // Confirm contract's nonce has been incremented
-      const nonce = Number(await this.erc20App.nonce());
-      nonce.should.be.bignumber.equal(beforeNonce+1);
     });
   });
 
@@ -108,6 +100,7 @@ contract("ERC20App", function (accounts) {
 
     before(async function () {
         this.erc20App = await ERC20App.new();
+        await this.erc20App.register(owner);
 
         // Set up an ERC20 token for testing token deposits
         this.symbol = "TEST";
@@ -119,7 +112,7 @@ contract("ERC20App", function (accounts) {
         }).should.be.fulfilled;
 
         // Prepare transaction parameters
-        const lockAmount = 5000;
+        const lockAmount = 10000;
         const recipient = Buffer.from(POLKADOT_ADDRESS, "hex");
 
         // Approve tokens to contract
@@ -141,7 +134,8 @@ contract("ERC20App", function (accounts) {
 
     it("should support ERC20 unlocks", async function () {
       // Encoded data
-      const encodedData = "0xd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27dcffeaaf7681c89285d65cfbe808b80e502696573eec918d74c746167564401103096D45BbD494B743412000000000000000000000000000000000000000000000000000000000000"
+      const encodedTokenAddress = this.token.address.slice(2, this.token.address.length);
+      const encodedData = "0xd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27dcffeaaf7681c89285d65cfbe808b80e502696573" + encodedTokenAddress + "3412000000000000000000000000000000000000000000000000000000000000"
       // Decoded data
       const decodedSender = "0xd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d";
       const decodedRecipient = "0xCfFEAAf7681c89285D65CfbE808b80e502696573";

--- a/ethereum/test/test_eth_app.js
+++ b/ethereum/test/test_eth_app.js
@@ -8,7 +8,7 @@ require("chai")
   .use(require("chai-bignumber")(BigNumber))
   .should();
 
-contract("Bank", function (accounts) {
+contract("EthApp", function (accounts) {
   // Accounts
   const owner = accounts[0];
   const userOne = accounts[1];
@@ -24,9 +24,6 @@ contract("Bank", function (accounts) {
 
     it("should deploy and initialize the ETHApp contract", async function () {
       this.ethApp.should.exist;
-
-      const nonce = Number(await this.ethApp.nonce());
-      nonce.should.be.bignumber.equal(0);
     });
   });
 
@@ -38,7 +35,6 @@ contract("Bank", function (accounts) {
     it("should support Ethereum deposits", async function () {
       // Load initial contract state
       const beforeTotalETH = Number(await this.ethApp.totalETH());
-      const beforeNonce = Number(await this.ethApp.nonce());
 
       // Prepare transaction parameters
       const recipient = Buffer.from(POLKADOT_ADDRESS, "hex");
@@ -68,10 +64,6 @@ contract("Bank", function (accounts) {
       // Confirm contract's locked Ethereum counter has increased by amount locked
       const afterTotalETH = await this.ethApp.totalETH();
       Number(afterTotalETH).should.be.bignumber.equal(beforeTotalETH+Number(weiAmount));
-
-      // Confirm contract's nonce has been incremented
-      const nonce = Number(await this.ethApp.nonce());
-      nonce.should.be.bignumber.equal(beforeNonce+1);
     });
   });
 
@@ -80,6 +72,7 @@ contract("Bank", function (accounts) {
 
     before(async function () {
         this.ethApp = await ETHApp.new();
+        await this.ethApp.register(owner);
 
         // Prepare transaction parameters
         const lockAmountWei = 5000;


### PR DESCRIPTION
This PR update applications with a simple `msg.sender` check so that only Bridge can call the handle method on applications. The Bridge contract registers its address on each application during initial on-contract app verification. Messages submitted to the Bridge by the relayer will be routed from Bridge contract -> application contract successfully and other actors won’t be able to send fabricated messages directly to the applications.