### PR TITLE
Fix ETH unlock edge case

### DIFF
--- a/ethereum/contracts/ETHApp.sol
+++ b/ethereum/contracts/ETHApp.sol
@@ -61,7 +61,11 @@ contract ETHApp is Application {
         internal
     {
         require(_amount > 0, "Must unlock a positive amount");
-        require(totalETH > _amount, "ETH token balances insufficient to fulfill the unlock request");
+
+        // If amount is greater than available balances, set amount to max available
+        if(totalETH < _amount) {
+            _amount = totalETH;
+        }
 
         totalETH = totalETH.sub(_amount);
         _recipient.transfer(_amount);

--- a/ethereum/contracts/ETHApp.sol
+++ b/ethereum/contracts/ETHApp.sol
@@ -61,11 +61,7 @@ contract ETHApp is Application {
         internal
     {
         require(_amount > 0, "Must unlock a positive amount");
-
-        // If amount is greater than available balances, set amount to max available
-        if(totalETH < _amount) {
-            _amount = totalETH;
-        }
+        require(totalETH >= _amount, "ETH token balances insufficient to fulfill the unlock request");
 
         totalETH = totalETH.sub(_amount);
         _recipient.transfer(_amount);


### PR DESCRIPTION
Addresses https://github.com/Snowfork/polkadot-ethereum/issues/121 by catching an edge case when the available amount on the ETH Application is slightly less than the unlock request by setting the requested unlock amount to the maximum available amount. 