### PR TITLE
Ethash configuration via runtime parameter

### DIFF
--- a/parachain/node/src/chain_spec.rs
+++ b/parachain/node/src/chain_spec.rs
@@ -159,7 +159,6 @@ fn testnet_genesis(
 		verifier_lightclient: Some(VerifierLightclientConfig {
 			initial_header: Default::default(),
 			initial_difficulty: 0.into(),
-			verify_pow: false,
 		}),
 	}
 }

--- a/parachain/pallets/verifier-lightclient/src/lib.rs
+++ b/parachain/pallets/verifier-lightclient/src/lib.rs
@@ -38,7 +38,7 @@ pub struct StoredHeader<Submitter> {
 pub trait Trait: system::Trait {
 	type Event: From<Event> + Into<<Self as system::Trait>::Event>;
 	// Determines whether Ethash PoW is verified for headers
-	// NOTE: true by default, should only be false for dev
+	// NOTE: Should only be false for dev
 	type VerifyPoW: Get<bool>;
 }
 

--- a/parachain/pallets/verifier-lightclient/src/lib.rs
+++ b/parachain/pallets/verifier-lightclient/src/lib.rs
@@ -23,19 +23,6 @@ mod mock;
 #[cfg(test)]
 mod tests;
 
-#[derive(Clone, PartialEq, RuntimeDebug)]
-pub struct EthashConfiguration {
-	// Determines whether Ethash PoW is verified for headers
-	// NOTE: true by default, should only be false for dev
-	pub verify_pow: bool,
-}
-
-impl Default for EthashConfiguration {
-	fn default() -> Self {
-		EthashConfiguration { verify_pow: true }
-	}
-}
-
 /// Ethereum block header as it is stored in the runtime storage.
 #[derive(Clone, Encode, Decode, PartialEq, RuntimeDebug)]
 pub struct StoredHeader<Submitter> {
@@ -50,8 +37,9 @@ pub struct StoredHeader<Submitter> {
 
 pub trait Trait: system::Trait {
 	type Event: From<Event> + Into<<Self as system::Trait>::Event>;
-	/// Ethash PoW configuration
-	type EthashConfiguration: Get<EthashConfiguration>;
+	// Determines whether Ethash PoW is verified for headers
+	// NOTE: true by default, should only be false for dev
+	type VerifyPoW: Get<bool>;
 }
 
 decl_storage! {
@@ -142,7 +130,7 @@ impl<T: Trait> Module<T> {
 			Error::<T>::DuplicateHeader,
 		);
 
-		if !T::EthashConfiguration::get().verify_pow {
+		if !T::VerifyPoW::get() {
 			return Ok(());
 		}
 

--- a/parachain/pallets/verifier-lightclient/src/mock.rs
+++ b/parachain/pallets/verifier-lightclient/src/mock.rs
@@ -1,6 +1,6 @@
 // Mock runtime
 use artemis_testutils::BlockWithProofs;
-use crate::{Module, EthashConfiguration, EthashProofData, EthereumHeader, GenesisConfig, Trait};
+use crate::{Module, EthashProofData, EthereumHeader, GenesisConfig, Trait};
 use sp_core::H256;
 use frame_support::{impl_outer_origin, impl_outer_event, parameter_types, weights::Weight};
 use sp_runtime::{
@@ -40,8 +40,6 @@ parameter_types! {
 	pub const MaximumBlockWeight: Weight = 1024;
 	pub const MaximumBlockLength: u32 = 2 * 1024;
 	pub const AvailableBlockRatio: Perbill = Perbill::from_percent(75);
-	pub EthashDisabledConfiguration: EthashConfiguration = EthashConfiguration { verify_pow: false };
-	pub EthashEnabledConfiguration: EthashConfiguration = EthashConfiguration::default();
 }
 
 impl system::Trait for MockRuntime {
@@ -100,15 +98,19 @@ impl system::Trait for MockRuntimeWithPoW {
 	type SystemWeightInfo = ();
 }
 
+parameter_types! {
+	pub const PowDisabled: bool = false;
+	pub const PowEnabled: bool = true;
+}
 
 impl Trait for MockRuntime {
 	type Event = MockEvent;
-	type EthashConfiguration = EthashDisabledConfiguration;
+	type VerifyPoW = PowDisabled;
 }
 
 impl Trait for MockRuntimeWithPoW {
 	type Event = MockEvent;
-	type EthashConfiguration = EthashEnabledConfiguration;
+	type VerifyPoW = PowEnabled;
 }
 
 pub type Verifier = Module<MockRuntime>;

--- a/parachain/pallets/verifier-lightclient/src/mock.rs
+++ b/parachain/pallets/verifier-lightclient/src/mock.rs
@@ -1,6 +1,6 @@
 // Mock runtime
 use artemis_testutils::BlockWithProofs;
-use crate::{Module, EthashProofData, EthereumHeader, GenesisConfig, Trait};
+use crate::{Module, EthashConfiguration, EthashProofData, EthereumHeader, GenesisConfig, Trait};
 use sp_core::H256;
 use frame_support::{impl_outer_origin, impl_outer_event, parameter_types, weights::Weight};
 use sp_runtime::{
@@ -32,11 +32,16 @@ pub type AccountId = <<Signature as Verify>::Signer as IdentifyAccount>::Account
 #[derive(Clone, Eq, PartialEq)]
 pub struct MockRuntime;
 
+#[derive(Clone, Eq, PartialEq)]
+pub struct MockRuntimeWithPoW;
+
 parameter_types! {
 	pub const BlockHashCount: u64 = 250;
 	pub const MaximumBlockWeight: Weight = 1024;
 	pub const MaximumBlockLength: u32 = 2 * 1024;
 	pub const AvailableBlockRatio: Perbill = Perbill::from_percent(75);
+	pub EthashDisabledConfiguration: EthashConfiguration = EthashConfiguration { verify_pow: false };
+	pub EthashEnabledConfiguration: EthashConfiguration = EthashConfiguration::default();
 }
 
 impl system::Trait for MockRuntime {
@@ -67,12 +72,48 @@ impl system::Trait for MockRuntime {
 	type SystemWeightInfo = ();
 }
 
-impl Trait for MockRuntime {
+impl system::Trait for MockRuntimeWithPoW {
+	type BaseCallFilter = ();
+	type Origin = Origin;
+	type Call = ();
+	type Index = u64;
+	type BlockNumber = u64;
+	type Hash = H256;
+	type Hashing = BlakeTwo256;
+	type AccountId = AccountId;
+	type Lookup = IdentityLookup<Self::AccountId>;
+	type Header = Header;
 	type Event = MockEvent;
+	type BlockHashCount = BlockHashCount;
+	type MaximumBlockWeight = MaximumBlockWeight;
+	type DbWeight = ();
+	type BlockExecutionWeight = ();
+	type ExtrinsicBaseWeight = ();
+	type MaximumExtrinsicWeight = MaximumBlockWeight;
+	type MaximumBlockLength = MaximumBlockLength;
+	type AvailableBlockRatio = AvailableBlockRatio;
+	type Version = ();
+	type ModuleToIndex = ();
+	type AccountData = ();
+	type OnNewAccount = ();
+	type OnKilledAccount = ();
+	type SystemWeightInfo = ();
 }
 
-pub type System = system::Module<MockRuntime>;
+
+impl Trait for MockRuntime {
+	type Event = MockEvent;
+	type EthashConfiguration = EthashDisabledConfiguration;
+}
+
+impl Trait for MockRuntimeWithPoW {
+	type Event = MockEvent;
+	type EthashConfiguration = EthashEnabledConfiguration;
+}
+
 pub type Verifier = Module<MockRuntime>;
+
+pub type VerifierWithPoW = Module<MockRuntimeWithPoW>;
 
 pub fn genesis_ethereum_header() -> EthereumHeader {
 	Default::default()
@@ -104,19 +145,18 @@ pub fn ethereum_header_proof_from_file(block_num: u64) -> Vec<EthashProofData> {
 }
 
 pub fn new_tester() -> sp_io::TestExternalities {
-	new_tester_with_config(GenesisConfig {
+	new_tester_with_config::<MockRuntime>(GenesisConfig {
 		initial_header: genesis_ethereum_header(),
 		initial_difficulty: 0.into(),
-		verify_pow: false,
 	})
 }
 
-pub fn new_tester_with_config(config: GenesisConfig) -> sp_io::TestExternalities {
-	let mut storage = system::GenesisConfig::default().build_storage::<MockRuntime>().unwrap();
+pub fn new_tester_with_config<T: Trait>(config: GenesisConfig) -> sp_io::TestExternalities {
+	let mut storage = system::GenesisConfig::default().build_storage::<T>().unwrap();
 
-	config.assimilate_storage::<MockRuntime>(&mut storage).unwrap();
+	config.assimilate_storage::<T>(&mut storage).unwrap();
 
 	let mut ext: sp_io::TestExternalities = storage.into();
-	ext.execute_with(|| System::set_block_number(1));
+	ext.execute_with(|| system::Module::<T>::set_block_number(1.into()));
 	ext
 }

--- a/parachain/pallets/verifier-lightclient/src/tests.rs
+++ b/parachain/pallets/verifier-lightclient/src/tests.rs
@@ -1,7 +1,7 @@
 use crate::mock::{
 	child_of_genesis_ethereum_header, ethereum_header_from_file,
 	ethereum_header_proof_from_file, new_tester, new_tester_with_config,
-	AccountId, Verifier, MockRuntime, Origin,
+	AccountId, Verifier, VerifierWithPoW, MockRuntime, MockRuntimeWithPoW, Origin,
 };
 use crate::sp_api_hidden_includes_decl_storage::hidden_include::{StorageMap, StorageValue};
 use frame_support::{assert_err, assert_ok};
@@ -121,28 +121,27 @@ fn it_rejects_ethereum_header_before_parent() {
 
 #[test]
 fn it_validates_proof_of_work() {
-	new_tester_with_config(GenesisConfig {
-		initial_header: ethereum_header_from_file(11090290),
-		initial_difficulty: 0.into(),
-		verify_pow: true,
+	new_tester_with_config::<MockRuntimeWithPoW>(GenesisConfig {
+			initial_header: ethereum_header_from_file(11090290),
+			initial_difficulty: 0.into(),
 	}).execute_with(|| {
 		let header1 = ethereum_header_from_file(11090291);
 		let header1_proof = ethereum_header_proof_from_file(11090291);
 		let header2 = ethereum_header_from_file(11090292);
 
 		let ferdie: AccountId = Keyring::Ferdie.into();
-		assert_ok!(Verifier::import_header(
+		assert_ok!(VerifierWithPoW::import_header(
 			Origin::signed(ferdie.clone()),
 			header1,
 			header1_proof,
 		));
 		assert_err!(
-			Verifier::import_header(
+			VerifierWithPoW::import_header(
 				Origin::signed(ferdie),
 				header2,
 				Default::default(),
 			),
-			Error::<MockRuntime>::InvalidHeader,
+			Error::<MockRuntimeWithPoW>::InvalidHeader,
 		);
 	});
 }

--- a/parachain/runtime/src/lib.rs
+++ b/parachain/runtime/src/lib.rs
@@ -19,6 +19,7 @@ use sp_api::impl_runtime_apis;
 use sp_consensus_aura::sr25519::AuthorityId as AuraId;
 use pallet_grandpa::{AuthorityId as GrandpaId, AuthorityList as GrandpaAuthorityList};
 use pallet_grandpa::fg_primitives;
+use verifier_lightclient::EthashConfiguration;
 
 use sp_std::prelude::*;
 
@@ -264,8 +265,13 @@ impl verifier::Trait for Runtime {
 	type Event = Event;
 }
 
+parameter_types! {
+	pub EthashEnabledConfig: EthashConfiguration = EthashConfiguration { verify_pow: true };
+}
+
 impl verifier_lightclient::Trait for Runtime {
 	type Event = Event;
+	type EthashConfiguration = EthashEnabledConfig;
 }
 
 impl asset::Trait for Runtime {

--- a/parachain/runtime/src/lib.rs
+++ b/parachain/runtime/src/lib.rs
@@ -19,7 +19,6 @@ use sp_api::impl_runtime_apis;
 use sp_consensus_aura::sr25519::AuthorityId as AuraId;
 use pallet_grandpa::{AuthorityId as GrandpaId, AuthorityList as GrandpaAuthorityList};
 use pallet_grandpa::fg_primitives;
-use verifier_lightclient::EthashConfiguration;
 
 use sp_std::prelude::*;
 
@@ -266,12 +265,12 @@ impl verifier::Trait for Runtime {
 }
 
 parameter_types! {
-	pub EthashEnabledConfig: EthashConfiguration = EthashConfiguration { verify_pow: true };
+	pub const VerifyPoW: bool = true;
 }
 
 impl verifier_lightclient::Trait for Runtime {
 	type Event = Event;
-	type EthashConfiguration = EthashEnabledConfig;
+	type VerifyPoW = VerifyPoW;
 }
 
 impl asset::Trait for Runtime {


### PR DESCRIPTION
This diff changes the way we configure the Eth lightclient pallet. The intention is to use this approach for pruning / finalization configuration and whatever else we need in future.

**What I was doing before**: storing a `verify_pow` bool in storage. This is convenient but causes us to read from storage unnecessarily.

**What I'm doing now**: hardcoding it for the runtime in `impl verifier_lightclient::Trait for Runtime`. This mimics parity-bridges-common. The drawback is that multiple configurations (e.g. for tests) require more runtime implementation boilerplate.
