### PR TITLE
Eth header finalization & pruning

### DIFF
--- a/parachain/pallets/verifier-lightclient/src/lib.rs
+++ b/parachain/pallets/verifier-lightclient/src/lib.rs
@@ -256,7 +256,10 @@ impl<T: Trait> Module<T> {
 
 			// Finalize blocks if possible
 			let finalized_block_id = FinalizedBlock::get();
-			let new_finalized_block_id = Self::finalize_headers(&best_block_id, &finalized_block_id);
+			let new_finalized_block_id = Self::get_best_finalized_header(
+				&best_block_id,
+				&finalized_block_id,
+			);
 			if new_finalized_block_id != finalized_block_id {
 				FinalizedBlock::put(new_finalized_block_id);
 			}
@@ -278,7 +281,7 @@ impl<T: Trait> Module<T> {
 
 	// Return the latest block that can be finalized based on the given
 	// highest difficulty chain and previously finalized block.
-	fn finalize_headers(
+	fn get_best_finalized_header(
 		best_block_id: &EthereumHeaderId,
 		finalized_block_id: &EthereumHeaderId,
 	) -> EthereumHeaderId {

--- a/parachain/pallets/verifier-lightclient/src/lib.rs
+++ b/parachain/pallets/verifier-lightclient/src/lib.rs
@@ -53,7 +53,7 @@ struct PruningRange {
 
 pub trait Trait: system::Trait {
 	type Event: From<Event> + Into<<Self as system::Trait>::Event>;
-	/// The number of descendents, in the highest difficulty chain, a block
+	/// The number of descendants, in the highest difficulty chain, a block
 	/// needs to have in order to be considered final.
 	type DescendantsUntilFinalized: Get<u8>;
 	// Determines whether Ethash PoW is verified for headers
@@ -152,7 +152,6 @@ decl_module! {
 impl<T: Trait> Module<T> {
 	// Validate an Ethereum header for import
 	fn validate_header_to_import(header: &EthereumHeader, proof: &[EthashProofData]) -> DispatchResult {
-		// TODO: move contextless check first
 		let hash = header.compute_hash();
 		ensure!(
 			!Headers::<T>::contains_key(hash),
@@ -304,8 +303,9 @@ impl<T: Trait> Module<T> {
 		new_finalized_block_id
 	}
 
-	// Remove old headers, from oldest to newest, in the provided range.
-	// Only up to `max_headers_to_prune` will be removed.
+	// Remove old headers, from oldest to newest, in the provided range
+	// (adjusted to `prune_end` if newer). Only up to `max_headers_to_prune`
+	// will be removed.
 	fn prune_header_range(
 		pruning_range: &PruningRange,
 		max_headers_to_prune: u64,

--- a/parachain/pallets/verifier-lightclient/src/mock.rs
+++ b/parachain/pallets/verifier-lightclient/src/mock.rs
@@ -99,17 +99,20 @@ impl system::Trait for MockRuntimeWithPoW {
 }
 
 parameter_types! {
+	pub const DescendantsUntilFinalized: u8 = 2;
 	pub const PowDisabled: bool = false;
 	pub const PowEnabled: bool = true;
 }
 
 impl Trait for MockRuntime {
 	type Event = MockEvent;
+	type DescendantsUntilFinalized = DescendantsUntilFinalized;
 	type VerifyPoW = PowDisabled;
 }
 
 impl Trait for MockRuntimeWithPoW {
 	type Event = MockEvent;
+	type DescendantsUntilFinalized = DescendantsUntilFinalized;
 	type VerifyPoW = PowEnabled;
 }
 
@@ -121,13 +124,15 @@ pub fn genesis_ethereum_header() -> EthereumHeader {
 	Default::default()
 }
 
-pub fn genesis_ethereum_block_hash() -> H256 {
-	genesis_ethereum_header().compute_hash()
+pub fn child_of_genesis_ethereum_header() -> EthereumHeader {
+	child_of_header(&genesis_ethereum_header())
 }
 
-pub fn child_of_genesis_ethereum_header() -> EthereumHeader {
+pub fn child_of_header(header: &EthereumHeader) -> EthereumHeader {
 	let mut child: EthereumHeader = Default::default();
-	child.parent_hash = genesis_ethereum_block_hash();
+	child.difficulty = 1.into();
+	child.parent_hash = header.compute_hash();
+	child.number = header.number + 1;
 	child	
 }
 

--- a/parachain/pallets/verifier-lightclient/src/mock.rs
+++ b/parachain/pallets/verifier-lightclient/src/mock.rs
@@ -124,6 +124,10 @@ pub fn genesis_ethereum_header() -> EthereumHeader {
 	Default::default()
 }
 
+pub fn genesis_ethereum_block_hash() -> H256 {
+	genesis_ethereum_header().compute_hash()
+}
+
 pub fn child_of_genesis_ethereum_header() -> EthereumHeader {
 	child_of_header(&genesis_ethereum_header())
 }

--- a/parachain/runtime/src/lib.rs
+++ b/parachain/runtime/src/lib.rs
@@ -265,11 +265,13 @@ impl verifier::Trait for Runtime {
 }
 
 parameter_types! {
+	pub const DescendantsUntilFinalized: u8 = 35;
 	pub const VerifyPoW: bool = true;
 }
 
 impl verifier_lightclient::Trait for Runtime {
 	type Event = Event;
+	type DescendantsUntilFinalized = DescendantsUntilFinalized;
 	type VerifyPoW = VerifyPoW;
 }
 


### PR DESCRIPTION
This PR adds tracking of finalized Ethereum headers and pruning of old finalized headers. A header is considered final when it's in the highest difficulty chain and has at least 35 descendants (35 is the number of "confirmations" that Coinbase requires).

