### PR TITLE
Add tool to generate MMR sample data

### DIFF
--- a/relayer/go.mod
+++ b/relayer/go.mod
@@ -5,6 +5,7 @@ go 1.13
 require (
 	github.com/aristanetworks/goarista v0.0.0-20201012165903-2cb20defcd66 // indirect
 	github.com/btcsuite/btcd v0.20.1-beta // indirect
+	github.com/cbergoon/merkletree v0.2.0
 	github.com/centrifuge/go-substrate-rpc-client v2.0.0-rc6+incompatible
 	github.com/deckarep/golang-set v1.7.1 // indirect
 	github.com/ethereum/go-ethereum v1.9.22
@@ -17,7 +18,7 @@ require (
 	github.com/spf13/cobra v1.0.0
 	github.com/spf13/viper v1.7.0
 	github.com/stretchr/testify v1.4.0
-	golang.org/x/crypto v0.0.0-20201012173705-84dcc777aaee // indirect
+	golang.org/x/crypto v0.0.0-20201116153603-4be66e5b6582
 	golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208
 	golang.org/x/sys v0.0.0-20201014080544-cc95f250f6bc // indirect
 )

--- a/relayer/go.sum
+++ b/relayer/go.sum
@@ -70,6 +70,8 @@ github.com/btcsuite/goleveldb v0.0.0-20160330041536-7834afc9e8cd/go.mod h1:F+uVa
 github.com/btcsuite/snappy-go v0.0.0-20151229074030-0bdef8d06723/go.mod h1:8woku9dyThutzjeg+3xrA5iCpBRH8XEEg3lh6TiUghc=
 github.com/btcsuite/websocket v0.0.0-20150119174127-31079b680792/go.mod h1:ghJtEyQwv5/p4Mg4C0fgbePVuGr935/5ddU9Z3TmDRY=
 github.com/btcsuite/winsvc v1.0.0/go.mod h1:jsenWakMcC0zFBFurPLEAyrnc/teJEM1O46fmI40EZs=
+github.com/cbergoon/merkletree v0.2.0 h1:Bttqr3OuoiZEo4ed1L7fTasHka9II+BF9fhBfbNEEoQ=
+github.com/cbergoon/merkletree v0.2.0/go.mod h1:5c15eckUgiucMGDOCanvalj/yJnD+KAZj1qyJtRW5aM=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/centrifuge/go-substrate-rpc-client v2.0.0-rc6+incompatible h1:qnOQJ5XHl8ZoBJ4jJhfBEfxxa5VCyUDUDvx4KrYF/UA=
 github.com/centrifuge/go-substrate-rpc-client v2.0.0-rc6+incompatible/go.mod h1:GBMLH8MQs5g4FcrytcMm9uRgBnTL1LIkNTue6lUPhZU=
@@ -461,6 +463,8 @@ golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 h1:psW17arqaxU48Z5kZ0CQnk
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20201012173705-84dcc777aaee h1:4yd7jl+vXjalO5ztz6Vc1VADv+S/80LGJmyl1ROJ2AI=
 golang.org/x/crypto v0.0.0-20201012173705-84dcc777aaee/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.0.0-20201116153603-4be66e5b6582 h1:0WDrJ1E7UolDk1KhTXxxw3Fc8qtk5x7dHP431KHEJls=
+golang.org/x/crypto v0.0.0-20201116153603-4be66e5b6582/go.mod h1:tCqSYrHVcf3i63Co2FzBkTCo2gdF6Zak62921dSfraU=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=
@@ -536,6 +540,7 @@ golang.org/x/sys v0.0.0-20190606165138-5da285871e9c/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190624142023-c5567b49c5d0/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190904154756-749cb33beabd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191005200804-aed5e4c7ecf9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191120155948-bd437916bb0e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200122134326-e047566fdf82/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -548,6 +553,7 @@ golang.org/x/sys v0.0.0-20200814200057-3d37ad5750ed/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200824131525-c12d262b63d8/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201014080544-cc95f250f6bc h1:HVFDs9bKvTxP6bh1Rj9MCSo+UmafQtI8ZWDPVwVk9g4=
 golang.org/x/sys v0.0.0-20201014080544-cc95f250f6bc/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/term v0.0.0-20201113234701-d7a72108b828/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=

--- a/relayer/tools/gen-mmr.go
+++ b/relayer/tools/gen-mmr.go
@@ -29,10 +29,14 @@ type H256 [32]byte
 
 // Leaf node for MMR
 type MMRLeaf struct {
-	blockHash        H256
-	paraHeadsRoot    H256
+	// Relay chain block hash
+	blockHash H256
+	// Merkle root for Parachain block header hashes
+	paraHeadsRoot H256
+	// Has validator merkle roor
 	hasValidatorRoot bool
-	validatorRoot    H256
+	// Merkle root for validator public keys
+	validatorRoot H256
 }
 
 // hashing strategy for Merkle trees
@@ -40,7 +44,7 @@ func hashStrategy() hash.Hash {
 	return sha3.NewLegacyKeccak256()
 }
 
-// Merkle Tree for ParaHeads
+// Hashing strategy for ParaHead leaf nodes
 func (head ParaBlockHash) CalculateHash() ([]byte, error) {
 	h := sha3.NewLegacyKeccak256()
 	if _, err := h.Write(head[:]); err != nil {
@@ -53,7 +57,7 @@ func (head ParaBlockHash) Equals(other merkletree.Content) (bool, error) {
 	return head == other, nil
 }
 
-// Merkle Tree for validator keys
+// Hashing strategy for ValidatorPublicKey leaf nodes
 func (key ValidatorPublicKey) CalculateHash() ([]byte, error) {
 	h := sha3.NewLegacyKeccak256()
 	if _, err := h.Write(key); err != nil {
@@ -66,7 +70,7 @@ func (key ValidatorPublicKey) Equals(other merkletree.Content) (bool, error) {
 	return reflect.DeepEqual(key, other), nil
 }
 
-// Merkle Tree for MMRLeaf
+// Hashing strategy for MMRLeaf leaf nodes
 func (leaf MMRLeaf) CalculateHash() ([]byte, error) {
 	h := sha3.NewLegacyKeccak256()
 	if _, err := h.Write(leaf.blockHash[:]); err != nil {

--- a/relayer/tools/gen-mmr.go
+++ b/relayer/tools/gen-mmr.go
@@ -101,6 +101,7 @@ func makeValidatorKeypair() *Keypair {
 	public := pk.Public().(*ecdsa.PublicKey)
 
 	return &Keypair{
+		// FIXME: Its not clear whether this marshalling is compatible with Solidity!
 		publicBytes: elliptic.Marshal(elliptic.P256(), public.X, public.Y),
 		public:      public,
 		private:     pk,

--- a/relayer/tools/gen-mmr.go
+++ b/relayer/tools/gen-mmr.go
@@ -39,7 +39,7 @@ type MMRLeaf struct {
 	validatorRoot H256
 }
 
-// hashing strategy for Merkle trees
+// hashing strategy for interior Merkle tree nodes
 func hashStrategy() hash.Hash {
 	return sha3.NewLegacyKeccak256()
 }

--- a/relayer/tools/gen-mmr.go
+++ b/relayer/tools/gen-mmr.go
@@ -1,0 +1,171 @@
+package main
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"fmt"
+	"hash"
+
+	"reflect"
+
+	"github.com/cbergoon/merkletree"
+	secp256k1 "github.com/ethereum/go-ethereum/crypto"
+	"golang.org/x/crypto/blake2b"
+	"golang.org/x/crypto/sha3"
+)
+
+// Validator keypair (secp256k1)
+type Keypair struct {
+	publicBytes []byte
+	public      *ecdsa.PublicKey
+	private     *ecdsa.PrivateKey
+}
+
+type ValidatorPublicKey []byte
+type ParaBlockHash [32]byte
+
+// Uninterpreted hash type
+type H256 [32]byte
+
+// Leaf node for MMR
+type MMRLeaf struct {
+	blockHash        H256
+	paraHeadsRoot    H256
+	hasValidatorRoot bool
+	validatorRoot    H256
+}
+
+// hashing strategy for Merkle trees
+func hashStrategy() hash.Hash {
+	return sha3.NewLegacyKeccak256()
+}
+
+// Merkle Tree for ParaHeads
+func (head ParaBlockHash) CalculateHash() ([]byte, error) {
+	h := sha3.NewLegacyKeccak256()
+	if _, err := h.Write(head[:]); err != nil {
+		return nil, err
+	}
+	return h.Sum(nil), nil
+}
+
+func (head ParaBlockHash) Equals(other merkletree.Content) (bool, error) {
+	return head == other, nil
+}
+
+// Merkle Tree for validator keys
+func (key ValidatorPublicKey) CalculateHash() ([]byte, error) {
+	h := sha3.NewLegacyKeccak256()
+	if _, err := h.Write(key); err != nil {
+		return nil, err
+	}
+	return h.Sum(nil), nil
+}
+
+func (key ValidatorPublicKey) Equals(other merkletree.Content) (bool, error) {
+	return reflect.DeepEqual(key, other), nil
+}
+
+// Merkle Tree for MMRLeaf
+func (leaf MMRLeaf) CalculateHash() ([]byte, error) {
+	h := sha3.NewLegacyKeccak256()
+	if _, err := h.Write(leaf.blockHash[:]); err != nil {
+		return nil, err
+	}
+	return h.Sum(nil), nil
+}
+
+func (leaf MMRLeaf) Equals(other merkletree.Content) (bool, error) {
+	return leaf.blockHash == other.(MMRLeaf).blockHash, nil
+}
+
+// Generate a merkle root hash for arbitrary leaf nodes
+func merkleRoot(keys ...merkletree.Content) H256 {
+	tree, err := merkletree.NewTreeWithHashStrategy(keys, hashStrategy)
+	if err != nil {
+		panic(err)
+	}
+
+	var hash [32]byte
+	copy(hash[:], tree.MerkleRoot())
+	return hash
+}
+
+// Create a random validator keypair (secp256k1)
+func makeValidatorKeypair() *Keypair {
+	pk, err := secp256k1.GenerateKey()
+	if err != nil {
+		panic(err)
+	}
+
+	public := pk.Public().(*ecdsa.PublicKey)
+
+	return &Keypair{
+		publicBytes: elliptic.Marshal(elliptic.P256(), public.X, public.Y),
+		public:      public,
+		private:     pk,
+	}
+}
+
+// create a BLAKE2b hash for a mock relay chain header
+func makeRelayChainHead(id byte) [32]byte {
+	return blake2b.Sum256([]byte{id})
+}
+
+// create a KECCAK256 hash for a mock parachain header
+func makeParaChainHead(id byte) ParaBlockHash {
+	h := sha3.NewLegacyKeccak256()
+	if _, err := h.Write([]byte{id}); err != nil {
+		panic(err)
+	}
+	var head [32]byte
+	copy(head[:], h.Sum(nil))
+	return head
+}
+
+func main() {
+
+	alice := makeValidatorKeypair()
+	bob := makeValidatorKeypair()
+	alicePubKey := ValidatorPublicKey(alice.publicBytes)
+	bobPubKey := ValidatorPublicKey(bob.publicBytes)
+
+	node0 := MMRLeaf{
+		blockHash:        makeRelayChainHead(1),
+		paraHeadsRoot:    merkleRoot(makeParaChainHead(1), makeParaChainHead(2)),
+		hasValidatorRoot: true,
+		validatorRoot:    merkleRoot(alicePubKey, bobPubKey),
+	}
+
+	node1 := MMRLeaf{
+		blockHash:        makeRelayChainHead(2),
+		hasValidatorRoot: false,
+		paraHeadsRoot:    merkleRoot(makeParaChainHead(3), makeParaChainHead(4)),
+	}
+
+	node2 := MMRLeaf{
+		blockHash:        makeRelayChainHead(3),
+		hasValidatorRoot: false,
+		paraHeadsRoot:    merkleRoot(makeParaChainHead(5), makeParaChainHead(6)),
+	}
+
+	node3 := MMRLeaf{
+		blockHash:        makeRelayChainHead(4),
+		hasValidatorRoot: false,
+		paraHeadsRoot:    merkleRoot(makeParaChainHead(7), makeParaChainHead(8)),
+	}
+
+	tree, err := merkletree.NewTreeWithHashStrategy([]merkletree.Content{node0, node1, node2, node3}, hashStrategy)
+	if err != nil {
+		panic(err)
+	}
+
+	valid, err := tree.VerifyTree()
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println("MMR Peak: ", tree.MerkleRoot())
+	fmt.Println("MMR is valid: ", valid)
+
+}


### PR DESCRIPTION
Added a tool which generates mock MMR data. This is just the start and of course we can improve it further in various ways (MMR serialization, printing, etc)

The only caveat is that it only generates balanced/binary merkle trees, which of course are still valid MMRs. Generating real-world MMRs is a bit trickier since there don't seem to be any suitable MMR golang libraries.

*Note: Will probably rewrite this in Rust so we can match better match substrate things*

The MMR consists of 4 leaf nodes, and a single peak:
```
      R
   /    \
 / \    / \       
0   1  2   3
```

Merkle tree implementation uses https://godoc.org/github.com/cbergoon/merkletree.

To compile:
```
go build -o build/gen-mmr tools/gen-mmr.go
```

To run:
```
build/gen-mmr
```