### PR TITLE
Misc improvements to relayer <-> Substrate

### DIFF
--- a/relayer/chain/ethereum/chain.go
+++ b/relayer/chain/ethereum/chain.go
@@ -5,7 +5,7 @@ package ethereum
 
 import (
 	"context"
-	"encoding/hex"
+	"fmt"
 
 	"github.com/snowfork/polkadot-ethereum/relayer/chain"
 	"golang.org/x/sync/errgroup"
@@ -74,6 +74,10 @@ func (ch *Chain) SetSender(ethMessages chan<- chain.Message, ethHeaders chan<- c
 }
 
 func (ch *Chain) Start(ctx context.Context, eg *errgroup.Group, subInit chan<- chain.Init, ethInit <-chan chain.Init) error {
+	if ch.listener == nil && ch.writer == nil {
+		return fmt.Errorf("Sender and/or receiver need to be set before starting chain")
+	}
+
 	err := ch.conn.Connect(ctx)
 	if err != nil {
 		return err
@@ -87,7 +91,7 @@ func (ch *Chain) Start(ctx context.Context, eg *errgroup.Group, subInit chan<- c
 		ethInitHeaderID := (<-ethInit).(*HeaderID)
 		ch.log.WithFields(logrus.Fields{
 			"blockNumber": ethInitHeaderID.Number,
-			"blockHash":   hex.EncodeToString(ethInitHeaderID.Hash[:]),
+			"blockHash":   ethInitHeaderID.Hash.Hex(),
 		}).Info("Received init params for Ethereum from Substrate")
 
 		if ch.listener != nil {

--- a/relayer/chain/ethereum/chain.go
+++ b/relayer/chain/ethereum/chain.go
@@ -92,7 +92,7 @@ func (ch *Chain) Start(ctx context.Context, eg *errgroup.Group, subInit chan<- c
 		ch.log.WithFields(logrus.Fields{
 			"blockNumber": ethInitHeaderID.Number,
 			"blockHash":   ethInitHeaderID.Hash.Hex(),
-		}).Info("Received init params for Ethereum from Substrate")
+		}).Debug("Received init params for Ethereum from Substrate")
 
 		if ch.listener != nil {
 			err = ch.listener.Start(ctx, eg, uint64(ethInitHeaderID.Number))

--- a/relayer/chain/ethereum/header_cache_state_test.go
+++ b/relayer/chain/ethereum/header_cache_state_test.go
@@ -3,7 +3,6 @@ package ethereum_test
 import (
 	"testing"
 
-	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/snowfork/polkadot-ethereum/relayer/chain/ethereum"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -21,7 +20,6 @@ func (tl *TestCacheLoader) MakeCache(epoch uint64) (*ethashproof.DatasetMerkleTr
 }
 
 func TestHeaderCacheState(t *testing.T) {
-	logger, _ := test.NewNullLogger()
 	eg := &errgroup.Group{}
 	cacheLoader := TestCacheLoader{}
 	cacheLoader.On("MakeCache", uint64(0)).Return(&ethashproof.DatasetMerkleTreeCache{Epoch: 0}, nil)
@@ -30,7 +28,7 @@ func TestHeaderCacheState(t *testing.T) {
 	cacheLoader.On("MakeCache", uint64(3)).Return(&ethashproof.DatasetMerkleTreeCache{Epoch: 3}, nil)
 
 	// Should load epoch 0 and 1 caches
-	hcs, err := ethereum.NewHeaderCacheState(eg, 0, logger.WithField("test", "ing"), &cacheLoader)
+	hcs, err := ethereum.NewHeaderCacheState(eg, 0, &cacheLoader)
 	if err != nil {
 		panic(err)
 	}

--- a/relayer/chain/ethereum/listener.go
+++ b/relayer/chain/ethereum/listener.go
@@ -57,7 +57,7 @@ func (li *Listener) pollEventsAndHeaders(ctx context.Context, initBlockHeight ui
 	if li.messages == nil {
 		li.log.Info("Not polling events since channel is nil")
 	} else {
-		li.log.Info("Polling events started")
+		li.log.Info("Polling events starting...")
 
 		query := makeFilterQuery(li.contracts)
 
@@ -76,7 +76,7 @@ func (li *Listener) pollEventsAndHeaders(ctx context.Context, initBlockHeight ui
 		}
 	}
 
-	li.log.Info("Polling headers started")
+	li.log.Info("Polling headers starting...")
 
 	currentBlock := initBlockHeight
 	newestBlock := uint64(0)
@@ -118,6 +118,7 @@ func (li *Listener) pollEventsAndHeaders(ctx context.Context, initBlockHeight ui
 			blockNumber := gethheader.Number.Uint64()
 			newestBlock = blockNumber
 			li.log.WithFields(logrus.Fields{
+				"blockHash":   gethheader.Hash().Hex(),
 				"blockNumber": blockNumber,
 			}).Info("Witnessed new block header")
 
@@ -137,6 +138,7 @@ func (li *Listener) pollEventsAndHeaders(ctx context.Context, initBlockHeight ui
 				}).Error("Failed to retrieve old block header")
 			} else {
 				li.log.WithFields(logrus.Fields{
+					"blockHash":   gethheader.Hash().Hex(),
 					"blockNumber": currentBlock,
 				}).Info("Retrieved old block header")
 				li.forwardHeader(hcs, gethheader)
@@ -150,7 +152,7 @@ func (li *Listener) forwardHeader(hcs *HeaderCacheState, gethheader *gethTypes.H
 	cache, err := hcs.GetEthashproofCache(gethheader.Number.Uint64())
 	if err != nil {
 		li.log.WithFields(logrus.Fields{
-			"blockHash":   gethheader.Hash(),
+			"blockHash":   gethheader.Hash().Hex(),
 			"blockNumber": gethheader.Number,
 		}).Error("Failed to get ethashproof cache for header")
 	}
@@ -158,7 +160,7 @@ func (li *Listener) forwardHeader(hcs *HeaderCacheState, gethheader *gethTypes.H
 	header, err := MakeHeaderFromEthHeader(gethheader, cache, li.log)
 	if err != nil {
 		li.log.WithFields(logrus.Fields{
-			"blockHash":   gethheader.Hash(),
+			"blockHash":   gethheader.Hash().Hex(),
 			"blockNumber": gethheader.Number,
 		}).Error("Failed to generate header from ethereum header")
 	} else {

--- a/relayer/chain/ethereum/writer.go
+++ b/relayer/chain/ethereum/writer.go
@@ -62,11 +62,20 @@ func (wr *Writer) Start(ctx context.Context, eg *errgroup.Group) error {
 	return nil
 }
 
+func (wr *Writer) onDone(ctx context.Context) error {
+	wr.log.Info("Shutting down writer...")
+	// Avoid deadlock if a listener is still trying to send to a channel
+	for m := range wr.messages {
+		wr.log.WithFields(logrus.Fields{"message": m}).Debug("Discarded")
+	}
+	return ctx.Err()
+}
+
 func (wr *Writer) writeLoop(ctx context.Context) error {
 	for {
 		select {
 		case <-ctx.Done():
-			return ctx.Err()
+			return wr.onDone(ctx)
 		case msg := <-wr.messages:
 			err := wr.Write(ctx, &msg)
 			if err != nil {

--- a/relayer/chain/ethereum/writer.go
+++ b/relayer/chain/ethereum/writer.go
@@ -65,8 +65,8 @@ func (wr *Writer) Start(ctx context.Context, eg *errgroup.Group) error {
 func (wr *Writer) onDone(ctx context.Context) error {
 	wr.log.Info("Shutting down writer...")
 	// Avoid deadlock if a listener is still trying to send to a channel
-	for m := range wr.messages {
-		wr.log.WithFields(logrus.Fields{"message": m}).Debug("Discarded")
+	for range wr.messages {
+		wr.log.Debug("Discarded message")
 	}
 	return ctx.Err()
 }

--- a/relayer/chain/substrate/chain.go
+++ b/relayer/chain/substrate/chain.go
@@ -5,7 +5,7 @@ package substrate
 
 import (
 	"context"
-	"encoding/hex"
+	"fmt"
 
 	"golang.org/x/sync/errgroup"
 
@@ -65,6 +65,10 @@ func (ch *Chain) SetSender(subMessages chan<- chain.Message, _ chan<- chain.Head
 }
 
 func (ch *Chain) Start(ctx context.Context, eg *errgroup.Group, ethInit chan<- chain.Init, _ <-chan chain.Init) error {
+	if ch.listener == nil && ch.writer == nil {
+		return fmt.Errorf("Sender and/or receiver need to be set before starting chain")
+	}
+
 	err := ch.conn.Connect(ctx)
 	if err != nil {
 		return err
@@ -78,7 +82,7 @@ func (ch *Chain) Start(ctx context.Context, eg *errgroup.Group, ethInit chan<- c
 	}
 	ch.log.WithFields(logrus.Fields{
 		"blockNumber": ethInitHeaderID.Number,
-		"blockHash":   hex.EncodeToString(ethInitHeaderID.Hash[:]),
+		"blockHash":   ethInitHeaderID.Hash.Hex(),
 	}).Info("Retrieved init params for Ethereum from Substrate")
 	ethInit <- ethInitHeaderID
 	close(ethInit)

--- a/relayer/chain/substrate/chain.go
+++ b/relayer/chain/substrate/chain.go
@@ -126,6 +126,6 @@ func (ch *Chain) queryEthereumInitParams() (*ethereum.HeaderID, error) {
 		return nil, err
 	}
 
-	headerID.Number = types.NewU64(uint64(headerID.Number) + 1)
-	return &headerID, nil
+	nextHeaderID := ethereum.HeaderID{Number: types.NewU64(uint64(headerID.Number) + 1)}
+	return &nextHeaderID, nil
 }

--- a/relayer/chain/substrate/events_test.go
+++ b/relayer/chain/substrate/events_test.go
@@ -29,12 +29,12 @@ func TestDecodeEvents(t *testing.T) {
 			{
 				ID:     [2]uint8{0x0, 0x0},
 				Name:   [2]string{"System", "ExtrinsicSuccess"},
-				Phase:  types.Phase{IsApplyExtrinsic: true, AsApplyExtrinsic: 0x0, IsFinalization: false, IsInitialization: false},
+				Phase:  types.Phase{IsApplyExtrinsic: true, AsApplyExtrinsic: 0x0, IsFinalization: false},
 				Topics: []types.Hash{},
 				Fields: SystemExtrinsicSuccess{
 					DispatchInfo: types.DispatchInfo{
 						Weight:  0x96ae380,
-						Class:   types.DispatchClass{IsNormal: false, IsOperational: false, IsMandatory: true},
+						Class:   types.DispatchClass{IsNormal: false, IsOperational: false},
 						PaysFee: false,
 					},
 				},
@@ -42,7 +42,7 @@ func TestDecodeEvents(t *testing.T) {
 			{
 				ID:     [2]uint8{0x2, 0x2},
 				Name:   [2]string{"Balances", "Transfer"},
-				Phase:  types.Phase{IsApplyExtrinsic: true, AsApplyExtrinsic: 0x1, IsFinalization: false, IsInitialization: false},
+				Phase:  types.Phase{IsApplyExtrinsic: true, AsApplyExtrinsic: 0x1, IsFinalization: false},
 				Topics: []types.Hash{},
 				Fields: BalancesTransfer{
 					From: types.AccountID{0xd4, 0x35, 0x93, 0xc7, 0x15, 0xfd, 0xd3, 0x1c, 0x61, 0x14, 0x1a, 0xbd, 0x4, 0xa9, 0x9f, 0xd6, 0x82, 0x2c, 0x85, 0x58, 0x85, 0x4c, 0xcd, 0xe3, 0x9a, 0x56, 0x84, 0xe7, 0xa5, 0x6d, 0xa2, 0x7d},
@@ -55,12 +55,12 @@ func TestDecodeEvents(t *testing.T) {
 			{
 				ID:     [2]uint8{0x0, 0x0},
 				Name:   [2]string{"System", "ExtrinsicSuccess"},
-				Phase:  types.Phase{IsApplyExtrinsic: true, AsApplyExtrinsic: 0x1, IsFinalization: false, IsInitialization: false},
+				Phase:  types.Phase{IsApplyExtrinsic: true, AsApplyExtrinsic: 0x1, IsFinalization: false},
 				Topics: []types.Hash{},
 				Fields: SystemExtrinsicSuccess{
 					DispatchInfo: types.DispatchInfo{
 						Weight:  0xb9f76c0,
-						Class:   types.DispatchClass{IsNormal: true, IsOperational: false, IsMandatory: false},
+						Class:   types.DispatchClass{IsNormal: true, IsOperational: false},
 						PaysFee: false,
 					},
 				},

--- a/relayer/chain/substrate/listener.go
+++ b/relayer/chain/substrate/listener.go
@@ -44,6 +44,12 @@ func (li *Listener) Start(ctx context.Context, eg *errgroup.Group) error {
 	return nil
 }
 
+func (li *Listener) onDone(ctx context.Context) error {
+	li.log.Info("Shutting down listener...")
+	close(li.messages)
+	return ctx.Err()
+}
+
 func (li *Listener) pollBlocks(ctx context.Context) error {
 	if li.messages == nil {
 		li.log.Info("Not polling events since channel is nil")
@@ -66,7 +72,7 @@ func (li *Listener) pollBlocks(ctx context.Context) error {
 	for {
 		select {
 		case <-ctx.Done():
-			return ctx.Err()
+			return li.onDone(ctx)
 		default:
 
 			li.log.WithField("block", currentBlock).Debug("Processing block")

--- a/relayer/chain/substrate/writer.go
+++ b/relayer/chain/substrate/writer.go
@@ -19,12 +19,11 @@ import (
 )
 
 type Writer struct {
-	conn         *Connection
-	messages     <-chan chain.Message
-	headers      <-chan chain.Header
-	log          *logrus.Entry
-	nonce        uint32
-	nonceCounter uint32
+	conn     *Connection
+	messages <-chan chain.Message
+	headers  <-chan chain.Header
+	log      *logrus.Entry
+	nonce    uint32
 }
 
 func NewWriter(conn *Connection, messages <-chan chain.Message, headers <-chan chain.Header, log *logrus.Entry) (*Writer, error) {
@@ -42,7 +41,6 @@ func (wr *Writer) Start(ctx context.Context, eg *errgroup.Group) error {
 		return err
 	}
 	wr.nonce = nonce
-	wr.nonceCounter = 0
 
 	eg.Go(func() error {
 		return wr.writeLoop(ctx)
@@ -128,7 +126,7 @@ func (wr *Writer) write(_ context.Context, c types.Call) error {
 		BlockHash:          genesisHash,
 		Era:                era,
 		GenesisHash:        genesisHash,
-		Nonce:              types.NewUCompactFromUInt(uint64(wr.nonce + wr.nonceCounter)),
+		Nonce:              types.NewUCompactFromUInt(uint64(wr.nonce)),
 		SpecVersion:        rv.SpecVersion,
 		Tip:                types.NewUCompactFromUInt(0),
 		TransactionVersion: 1,
@@ -146,7 +144,7 @@ func (wr *Writer) write(_ context.Context, c types.Call) error {
 		return err
 	}
 
-	wr.nonceCounter = wr.nonceCounter + 1
+	wr.nonce = wr.nonce + 1
 
 	return nil
 }

--- a/relayer/chain/substrate/writer_test.go
+++ b/relayer/chain/substrate/writer_test.go
@@ -28,11 +28,12 @@ func TestWrite(t *testing.T) {
 	conn := substrate.NewConnection("ws://127.0.0.1:9944/", sr25519.Alice().AsKeyringPair(), log)
 
 	messages := make(chan chain.Message, 1)
+	headers := make(chan chain.Header, 1)
 	ctx, cancel := context.WithCancel(context.Background())
 	eg, ctx := errgroup.WithContext(ctx)
 	defer cancel()
 
-	writer, err := substrate.NewWriter(conn, messages, log)
+	writer, err := substrate.NewWriter(conn, messages, headers, log)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -59,7 +60,7 @@ func TestWrite(t *testing.T) {
 		},
 	}
 
-	err = writer.Write(ctx, &chain.Message{AppID: AppID, Payload: message})
+	err = writer.WriteMessage(ctx, &chain.Message{AppID: AppID, Payload: message})
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This diff addresses feedback on #135 #159 and #166, and fixes up some annoying relayer issues. This includes:
* removing panics caused by `unwrap` in Substrate
* improved errors / logging in relayer. e.g. including block hash in logs
* `onDone` function in `Listener` and `Writer` to clean up channels and avoid deadlock when you try to kill the relayer
* incrementing the nonce used in Substrate extrinsics in the relayer
* fixing relayer unit tests that were broken (but undetected in Github test runs?)
