### PR TITLE
Fork-aware Eth header sync in relayer

### DIFF
--- a/relayer/chain/ethereum/listener.go
+++ b/relayer/chain/ethereum/listener.go
@@ -13,6 +13,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/snowfork/polkadot-ethereum/relayer/chain"
+	"github.com/snowfork/polkadot-ethereum/relayer/chain/ethereum/syncer"
 )
 
 // Listener streams the Ethereum blockchain for application events
@@ -89,7 +90,7 @@ func (li *Listener) pollEventsAndHeaders(ctx context.Context, initBlockHeight ui
 		}
 	}
 
-	headerSyncer := NewSyncer(li.conn, 35, headers, li.log)
+	headerSyncer := syncer.NewSyncer(35, syncer.NewHeaderLoader(li.conn.client), headers, li.log)
 
 	li.log.Info("Syncing headers starting...")
 	err := headerSyncer.StartSync(headerCtx, headerEg, initBlockHeight)

--- a/relayer/chain/ethereum/listener.go
+++ b/relayer/chain/ethereum/listener.go
@@ -5,7 +5,6 @@ package ethereum
 
 import (
 	"context"
-	"math/big"
 
 	geth "github.com/ethereum/go-ethereum"
 	gethCommon "github.com/ethereum/go-ethereum/common"
@@ -66,7 +65,7 @@ func (li *Listener) pollEventsAndHeaders(ctx context.Context, initBlockHeight ui
 	events := make(chan gethTypes.Log)
 	var eventsSubscriptionErr <-chan error
 	headers := make(chan *gethTypes.Header, 5)
-	var headersSubscriptionErr <-chan error
+	headerEg, headerCtx := errgroup.WithContext(ctx)
 
 	if li.messages == nil {
 		li.log.Info("Not polling events since channel is nil")
@@ -90,26 +89,24 @@ func (li *Listener) pollEventsAndHeaders(ctx context.Context, initBlockHeight ui
 		}
 	}
 
-	li.log.Info("Polling headers starting...")
+	headerSyncer := NewSyncer(li.conn, 35, headers, li.log)
 
-	currentBlock := initBlockHeight
-	newestBlock := uint64(0)
-	subscription, err := li.conn.client.SubscribeNewHead(ctx, headers)
+	li.log.Info("Syncing headers starting...")
+	err := headerSyncer.StartSync(headerCtx, headerEg, initBlockHeight)
 	if err != nil {
-		li.log.WithError(err).Error("Failed to subscribe to new headers")
+		li.log.WithError(err).Error("Failed to start header sync")
 		return err
 	}
-	headersSubscriptionErr = subscription.Err()
 
 	for {
 		select {
 		case <-ctx.Done():
 			return li.onDone(ctx)
+		case <-headerCtx.Done():
+			return li.onDone(ctx)
 		case err := <-eventsSubscriptionErr:
 			li.log.WithError(err).Error("Events subscription terminated")
-			return err
-		case err := <-headersSubscriptionErr:
-			li.log.WithError(err).Error("Headers subscription terminated")
+			li.onDone(ctx)
 			return err
 		case event := <-events:
 			li.log.WithFields(logrus.Fields{
@@ -120,35 +117,7 @@ func (li *Listener) pollEventsAndHeaders(ctx context.Context, initBlockHeight ui
 			}).Info("Witnessed transaction for application")
 			li.forwardEvent(ctx, hcs, &event)
 		case gethheader := <-headers:
-			blockNumber := gethheader.Number.Uint64()
-			newestBlock = blockNumber
-			li.log.WithFields(logrus.Fields{
-				"blockHash":   gethheader.Hash().Hex(),
-				"blockNumber": blockNumber,
-			}).Info("Witnessed new block header")
-
-			if blockNumber <= currentBlock+1 {
-				li.forwardHeader(hcs, gethheader)
-				currentBlock = blockNumber
-			}
-		default:
-			if currentBlock == newestBlock {
-				continue
-			}
-
-			gethheader, err := li.conn.client.HeaderByNumber(ctx, new(big.Int).SetUint64(currentBlock))
-			if err != nil {
-				li.log.WithFields(logrus.Fields{
-					"blockNumber": currentBlock,
-				}).WithError(err).Error("Failed to retrieve old block header")
-			} else {
-				li.log.WithFields(logrus.Fields{
-					"blockHash":   gethheader.Hash().Hex(),
-					"blockNumber": currentBlock,
-				}).Info("Retrieved old block header")
-				li.forwardHeader(hcs, gethheader)
-				currentBlock = currentBlock + 1
-			}
+			li.forwardHeader(hcs, gethheader)
 		}
 	}
 }

--- a/relayer/chain/ethereum/sync.go
+++ b/relayer/chain/ethereum/sync.go
@@ -1,0 +1,247 @@
+// Copyright 2020 Snowfork
+// SPDX-License-Identifier: LGPL-3.0-only
+
+package ethereum
+
+import (
+	"context"
+	"math/big"
+	"sync"
+
+	gethCommon "github.com/ethereum/go-ethereum/common"
+	gethTypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/sirupsen/logrus"
+	"golang.org/x/sync/errgroup"
+)
+
+type latestBlockInfo struct {
+	sync.Mutex
+	fetchFinalizedDone bool
+	height             uint64
+}
+
+type headerCacheItem struct {
+	header    *gethTypes.Header
+	forwarded bool
+}
+
+type headerCache struct {
+	headers           map[string]headerCacheItem
+	hashesByHeight    map[uint64][]string
+	maxHeight         uint64
+	minHeight         uint64
+	numHeightsToTrack uint64
+}
+
+func (hc *headerCache) Insert(header *gethTypes.Header) bool {
+	hash := header.Hash().Hex()
+	_, exists := hc.headers[hash]
+	if exists {
+		return true
+	}
+
+	// Don't track headers older than numHeightsToTrack. This means
+	// the range [minHeight, maxHeight] is always moving forward
+	height := header.Number.Uint64()
+	if height < hc.maxHeight-hc.numHeightsToTrack {
+		return false
+	}
+
+	hc.headers[hash] = headerCacheItem{
+		header:    header,
+		forwarded: false,
+	}
+
+	hashesAtHeight, heightExists := hc.hashesByHeight[height]
+	if heightExists {
+		hc.hashesByHeight[height] = append(hashesAtHeight, hash)
+	} else {
+		hc.hashesByHeight[height] = []string{hash}
+		if height < hc.minHeight {
+			hc.minHeight = height
+		} else if height > hc.maxHeight {
+			hc.maxHeight = height
+		}
+	}
+
+	hc.pruneUpTo(hc.maxHeight - hc.numHeightsToTrack)
+	return true
+}
+
+func (hc *headerCache) pruneUpTo(minHeightToKeep uint64) {
+	for h := hc.minHeight; h < minHeightToKeep; h++ {
+		hashesToRemove := hc.hashesByHeight[h]
+		delete(hc.hashesByHeight, h)
+		for _, hashToRemove := range hashesToRemove {
+			delete(hc.headers, hashToRemove)
+		}
+	}
+	hc.minHeight = minHeightToKeep
+}
+
+func (hc *headerCache) Get(hash gethCommon.Hash) (*headerCacheItem, bool) {
+	hashHex := hash.Hex()
+	item, exists := hc.headers[hashHex]
+	if exists {
+		return &item, true
+	}
+	return nil, false
+}
+
+type Syncer struct {
+	conn                  *Connection
+	descendantsUntilFinal uint64
+	headerCache           headerCache
+	headers               chan<- *gethTypes.Header
+	log                   *logrus.Entry
+}
+
+func NewSyncer(conn *Connection, descendantsUntilFinal uint64, headers chan<- *gethTypes.Header, log *logrus.Entry) *Syncer {
+	return &Syncer{
+		conn:                  conn,
+		descendantsUntilFinal: descendantsUntilFinal,
+		headerCache: headerCache{
+			headers:           make(map[string]headerCacheItem, descendantsUntilFinal),
+			hashesByHeight:    make(map[uint64][]string, descendantsUntilFinal),
+			maxHeight:         0,
+			minHeight:         ^uint64(0),
+			numHeightsToTrack: descendantsUntilFinal,
+		},
+		headers: headers,
+		log:     log,
+	}
+}
+
+func (s *Syncer) StartSync(ctx context.Context, eg *errgroup.Group, initBlockHeight uint64) error {
+	latestHeader, err := s.conn.client.HeaderByNumber(ctx, nil)
+	if err != nil {
+		s.log.WithError(err).Error("Failed to retrieve latest header")
+		return err
+	}
+
+	lbi := &latestBlockInfo{
+		fetchFinalizedDone: false,
+		height:             latestHeader.Number.Uint64(),
+	}
+
+	eg.Go(func() error {
+		return s.fetchFinalizedHeaders(ctx, initBlockHeight, lbi)
+	})
+	eg.Go(func() error {
+		return s.pollNewHeaders(ctx, lbi)
+	})
+
+	return nil
+}
+
+func (s *Syncer) fetchFinalizedHeaders(ctx context.Context, initBlockHeight uint64, lbi *latestBlockInfo) error {
+	syncedUpUntil := initBlockHeight
+
+	for {
+		lbi.Lock()
+		latestFinalizedHeight := lbi.height - s.descendantsUntilFinal
+		if syncedUpUntil >= latestFinalizedHeight {
+			// Signals to pollNewHeaders that new headers can be forwarded now
+			lbi.fetchFinalizedDone = true
+			lbi.Unlock()
+
+			s.log.WithField("blockNumber", syncedUpUntil).Debug("Done retrieving finalized headers")
+
+			break
+		}
+		lbi.Unlock()
+
+		header, err := s.conn.client.HeaderByNumber(ctx, new(big.Int).SetUint64(syncedUpUntil+1))
+		if err != nil {
+			s.log.WithField(
+				"blockNumber", syncedUpUntil+1,
+			).WithError(err).Error("Failed to retrieve finalized header")
+			// Only option is to retry
+			continue
+		}
+
+		s.log.WithFields(logrus.Fields{
+			"blockHash":   header.Hash().Hex(),
+			"blockNumber": syncedUpUntil + 1,
+		}).Debug("Retrieved finalized header")
+
+		s.headers <- header
+		syncedUpUntil++
+	}
+
+	return nil
+}
+
+func (s *Syncer) pollNewHeaders(ctx context.Context, lbi *latestBlockInfo) error {
+	headers := make(chan *gethTypes.Header)
+	var headersSubscriptionErr <-chan error
+
+	subscription, err := s.conn.client.SubscribeNewHead(ctx, headers)
+	if err != nil {
+		s.log.WithError(err).Error("Failed to subscribe to new headers")
+		return err
+	}
+	headersSubscriptionErr = subscription.Err()
+
+	for {
+		select {
+		case <-ctx.Done():
+			close(s.headers)
+			return ctx.Err()
+		case err := <-headersSubscriptionErr:
+			close(s.headers)
+			return err
+		case header := <-headers:
+			s.headerCache.Insert(header)
+			lbi.Lock()
+			lbi.height = header.Number.Uint64()
+
+			s.log.WithFields(logrus.Fields{
+				"blockHash":   header.Hash().Hex(),
+				"blockNumber": lbi.height,
+			}).Debug("Witnessed new header")
+
+			if lbi.fetchFinalizedDone {
+				err = s.forwardAncestry(ctx, header.Hash(), lbi.height-s.descendantsUntilFinal)
+				if err != nil {
+					s.log.WithFields(logrus.Fields{
+						"blockHash":   header.Hash().Hex(),
+						"blockNumber": lbi.height,
+					}).WithError(err).Error("Failed to forward header and its ancestors")
+				}
+			}
+			lbi.Unlock()
+		}
+	}
+}
+
+func (s *Syncer) forwardAncestry(ctx context.Context, hash gethCommon.Hash, oldestHeight uint64) error {
+	item, exists := s.headerCache.Get(hash)
+	if !exists {
+		header, err := s.conn.client.HeaderByHash(ctx, hash)
+		if err != nil {
+			return err
+		}
+
+		// If a header is too old, it cannot be inserted. We can assume it's already been forwarded
+		if !s.headerCache.Insert(header) {
+			return nil
+		}
+		item, _ = s.headerCache.Get(hash)
+	}
+
+	if item.forwarded {
+		return nil
+	}
+
+	if item.header.Number.Uint64() > oldestHeight {
+		err := s.forwardAncestry(ctx, item.header.ParentHash, oldestHeight)
+		if err != nil {
+			return err
+		}
+	}
+
+	s.headers <- item.header
+	item.forwarded = true
+	return nil
+}

--- a/relayer/chain/ethereum/syncer/cache.go
+++ b/relayer/chain/ethereum/syncer/cache.go
@@ -1,0 +1,89 @@
+// Copyright 2020 Snowfork
+// SPDX-License-Identifier: LGPL-3.0-only
+
+package syncer
+
+import (
+	gethCommon "github.com/ethereum/go-ethereum/common"
+	gethTypes "github.com/ethereum/go-ethereum/core/types"
+)
+
+type HeaderCacheItem struct {
+	Header    *gethTypes.Header
+	Forwarded bool
+}
+
+type HeaderCache struct {
+	headers           map[string]*HeaderCacheItem
+	hashesByHeight    map[uint64][]string
+	maxHeight         uint64
+	minHeight         uint64
+	numHeightsToTrack uint64
+}
+
+func NewHeaderCache(numHeightsToTrack uint64) *HeaderCache {
+	return &HeaderCache{
+		headers:           make(map[string]*HeaderCacheItem, numHeightsToTrack),
+		hashesByHeight:    make(map[uint64][]string, numHeightsToTrack),
+		maxHeight:         0,
+		minHeight:         ^uint64(0),
+		numHeightsToTrack: numHeightsToTrack,
+	}
+}
+
+func (hc *HeaderCache) Insert(header *gethTypes.Header) bool {
+	hash := header.Hash().Hex()
+	_, exists := hc.headers[hash]
+	if exists {
+		return true
+	}
+
+	// Don't track headers older than numHeightsToTrack. This means
+	// the range [minHeight, maxHeight] is always moving forward
+	height := header.Number.Uint64()
+	if hc.maxHeight >= hc.numHeightsToTrack && height <= hc.maxHeight-hc.numHeightsToTrack {
+		return false
+	}
+
+	hc.headers[hash] = &HeaderCacheItem{
+		Header:    header,
+		Forwarded: false,
+	}
+
+	hashesAtHeight, heightExists := hc.hashesByHeight[height]
+	if heightExists {
+		hc.hashesByHeight[height] = append(hashesAtHeight, hash)
+	} else {
+		hc.hashesByHeight[height] = []string{hash}
+		if height < hc.minHeight {
+			hc.minHeight = height
+		} else if height > hc.maxHeight {
+			hc.maxHeight = height
+		}
+	}
+
+	if hc.maxHeight >= hc.numHeightsToTrack {
+		hc.pruneUpTo(hc.maxHeight - hc.numHeightsToTrack + 1)
+	}
+	return true
+}
+
+func (hc *HeaderCache) pruneUpTo(minHeightToKeep uint64) {
+	for hc.minHeight < minHeightToKeep {
+		hashesToRemove := hc.hashesByHeight[hc.minHeight]
+		delete(hc.hashesByHeight, hc.minHeight)
+		hc.minHeight++
+		for _, hashToRemove := range hashesToRemove {
+			delete(hc.headers, hashToRemove)
+		}
+	}
+}
+
+func (hc *HeaderCache) Get(hash gethCommon.Hash) (*HeaderCacheItem, bool) {
+	hashHex := hash.Hex()
+	item, exists := hc.headers[hashHex]
+	if exists {
+		return item, true
+	}
+	return nil, false
+}

--- a/relayer/chain/ethereum/syncer/cache.go
+++ b/relayer/chain/ethereum/syncer/cache.go
@@ -13,6 +13,10 @@ type HeaderCacheItem struct {
 	Forwarded bool
 }
 
+// This is used to store the latest headers as they are published. Up to
+// `numHeightsToTrack` heights are stored. Once this number is reached, an old
+// height is pruned each time a new height is added. The current stored height
+// range is given by [minHeight, maxHeight].
 type HeaderCache struct {
 	headers           map[string]*HeaderCacheItem
 	hashesByHeight    map[uint64][]string
@@ -31,6 +35,9 @@ func NewHeaderCache(numHeightsToTrack uint64) *HeaderCache {
 	}
 }
 
+// Returns true if insertion was successful. Insertion will only fail
+// if a header is too old, i.e. we've seen at least `numHeightsToTrack`
+// newer heights
 func (hc *HeaderCache) Insert(header *gethTypes.Header) bool {
 	hash := header.Hash().Hex()
 	_, exists := hc.headers[hash]

--- a/relayer/chain/ethereum/syncer/loader.go
+++ b/relayer/chain/ethereum/syncer/loader.go
@@ -1,0 +1,40 @@
+// Copyright 2020 Snowfork
+// SPDX-License-Identifier: LGPL-3.0-only
+
+package syncer
+
+import (
+	"context"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum"
+	gethCommon "github.com/ethereum/go-ethereum/common"
+	gethTypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/ethclient"
+)
+
+type HeaderLoader interface {
+	HeaderByHash(ctx context.Context, hash gethCommon.Hash) (*gethTypes.Header, error)
+	HeaderByNumber(ctx context.Context, number *big.Int) (*gethTypes.Header, error)
+	SubscribeNewHead(ctx context.Context, ch chan<- *gethTypes.Header) (ethereum.Subscription, error)
+}
+
+type DefaultHeaderLoader struct {
+	client *ethclient.Client
+}
+
+func NewHeaderLoader(client *ethclient.Client) *DefaultHeaderLoader {
+	return &DefaultHeaderLoader{client: client}
+}
+
+func (d *DefaultHeaderLoader) HeaderByHash(ctx context.Context, hash gethCommon.Hash) (*gethTypes.Header, error) {
+	return d.client.HeaderByHash(ctx, hash)
+}
+
+func (d *DefaultHeaderLoader) HeaderByNumber(ctx context.Context, number *big.Int) (*gethTypes.Header, error) {
+	return d.client.HeaderByNumber(ctx, number)
+}
+
+func (d *DefaultHeaderLoader) SubscribeNewHead(ctx context.Context, ch chan<- *gethTypes.Header) (ethereum.Subscription, error) {
+	return d.client.SubscribeNewHead(ctx, ch)
+}

--- a/relayer/chain/ethereum/syncer/syncer.go
+++ b/relayer/chain/ethereum/syncer/syncer.go
@@ -88,8 +88,7 @@ func (s *Syncer) fetchFinalizedHeaders(ctx context.Context, initBlockHeight uint
 			s.log.WithField(
 				"blockNumber", syncedUpUntil+1,
 			).WithError(err).Error("Failed to retrieve finalized header")
-			// Only option is to retry
-			continue
+			return err
 		}
 
 		s.log.WithFields(logrus.Fields{

--- a/relayer/chain/ethereum/syncer/syncer.go
+++ b/relayer/chain/ethereum/syncer/syncer.go
@@ -20,6 +20,12 @@ type latestBlockInfo struct {
 	height             uint64
 }
 
+// Syncer retrieves headers starting at a given initial height up to the latest.
+// Headers are sent to the channel `headers` in order. If the initial height is
+// old, (finalized) headers in the canonical chain will be forwarded in quick succession
+// until we catch up with the unfinalized headers. From that point onwards, headers
+// on all forks are forwarded. A header is considered final if it has at least
+// `descendantsUntilFinal` descendants.
 type Syncer struct {
 	descendantsUntilFinal uint64
 	headerCache           HeaderCache

--- a/relayer/chain/ethereum/syncer/syncer.go
+++ b/relayer/chain/ethereum/syncer/syncer.go
@@ -1,7 +1,7 @@
 // Copyright 2020 Snowfork
 // SPDX-License-Identifier: LGPL-3.0-only
 
-package ethereum
+package syncer
 
 import (
 	"context"
@@ -20,100 +20,26 @@ type latestBlockInfo struct {
 	height             uint64
 }
 
-type headerCacheItem struct {
-	header    *gethTypes.Header
-	forwarded bool
-}
-
-type headerCache struct {
-	headers           map[string]headerCacheItem
-	hashesByHeight    map[uint64][]string
-	maxHeight         uint64
-	minHeight         uint64
-	numHeightsToTrack uint64
-}
-
-func (hc *headerCache) Insert(header *gethTypes.Header) bool {
-	hash := header.Hash().Hex()
-	_, exists := hc.headers[hash]
-	if exists {
-		return true
-	}
-
-	// Don't track headers older than numHeightsToTrack. This means
-	// the range [minHeight, maxHeight] is always moving forward
-	height := header.Number.Uint64()
-	if height < hc.maxHeight-hc.numHeightsToTrack {
-		return false
-	}
-
-	hc.headers[hash] = headerCacheItem{
-		header:    header,
-		forwarded: false,
-	}
-
-	hashesAtHeight, heightExists := hc.hashesByHeight[height]
-	if heightExists {
-		hc.hashesByHeight[height] = append(hashesAtHeight, hash)
-	} else {
-		hc.hashesByHeight[height] = []string{hash}
-		if height < hc.minHeight {
-			hc.minHeight = height
-		} else if height > hc.maxHeight {
-			hc.maxHeight = height
-		}
-	}
-
-	hc.pruneUpTo(hc.maxHeight - hc.numHeightsToTrack)
-	return true
-}
-
-func (hc *headerCache) pruneUpTo(minHeightToKeep uint64) {
-	for h := hc.minHeight; h < minHeightToKeep; h++ {
-		hashesToRemove := hc.hashesByHeight[h]
-		delete(hc.hashesByHeight, h)
-		for _, hashToRemove := range hashesToRemove {
-			delete(hc.headers, hashToRemove)
-		}
-	}
-	hc.minHeight = minHeightToKeep
-}
-
-func (hc *headerCache) Get(hash gethCommon.Hash) (*headerCacheItem, bool) {
-	hashHex := hash.Hex()
-	item, exists := hc.headers[hashHex]
-	if exists {
-		return &item, true
-	}
-	return nil, false
-}
-
 type Syncer struct {
-	conn                  *Connection
 	descendantsUntilFinal uint64
-	headerCache           headerCache
+	headerCache           HeaderCache
 	headers               chan<- *gethTypes.Header
+	loader                HeaderLoader
 	log                   *logrus.Entry
 }
 
-func NewSyncer(conn *Connection, descendantsUntilFinal uint64, headers chan<- *gethTypes.Header, log *logrus.Entry) *Syncer {
+func NewSyncer(descendantsUntilFinal uint64, loader HeaderLoader, headers chan<- *gethTypes.Header, log *logrus.Entry) *Syncer {
 	return &Syncer{
-		conn:                  conn,
 		descendantsUntilFinal: descendantsUntilFinal,
-		headerCache: headerCache{
-			headers:           make(map[string]headerCacheItem, descendantsUntilFinal),
-			hashesByHeight:    make(map[uint64][]string, descendantsUntilFinal),
-			maxHeight:         0,
-			minHeight:         ^uint64(0),
-			numHeightsToTrack: descendantsUntilFinal,
-		},
-		headers: headers,
-		log:     log,
+		headerCache:           *NewHeaderCache(descendantsUntilFinal + 1),
+		headers:               headers,
+		loader:                loader,
+		log:                   log,
 	}
 }
 
 func (s *Syncer) StartSync(ctx context.Context, eg *errgroup.Group, initBlockHeight uint64) error {
-	latestHeader, err := s.conn.client.HeaderByNumber(ctx, nil)
+	latestHeader, err := s.loader.HeaderByNumber(ctx, nil)
 	if err != nil {
 		s.log.WithError(err).Error("Failed to retrieve latest header")
 		return err
@@ -151,7 +77,7 @@ func (s *Syncer) fetchFinalizedHeaders(ctx context.Context, initBlockHeight uint
 		}
 		lbi.Unlock()
 
-		header, err := s.conn.client.HeaderByNumber(ctx, new(big.Int).SetUint64(syncedUpUntil+1))
+		header, err := s.loader.HeaderByNumber(ctx, new(big.Int).SetUint64(syncedUpUntil+1))
 		if err != nil {
 			s.log.WithField(
 				"blockNumber", syncedUpUntil+1,
@@ -176,7 +102,7 @@ func (s *Syncer) pollNewHeaders(ctx context.Context, lbi *latestBlockInfo) error
 	headers := make(chan *gethTypes.Header)
 	var headersSubscriptionErr <-chan error
 
-	subscription, err := s.conn.client.SubscribeNewHead(ctx, headers)
+	subscription, err := s.loader.SubscribeNewHead(ctx, headers)
 	if err != nil {
 		s.log.WithError(err).Error("Failed to subscribe to new headers")
 		return err
@@ -218,7 +144,7 @@ func (s *Syncer) pollNewHeaders(ctx context.Context, lbi *latestBlockInfo) error
 func (s *Syncer) forwardAncestry(ctx context.Context, hash gethCommon.Hash, oldestHeight uint64) error {
 	item, exists := s.headerCache.Get(hash)
 	if !exists {
-		header, err := s.conn.client.HeaderByHash(ctx, hash)
+		header, err := s.loader.HeaderByHash(ctx, hash)
 		if err != nil {
 			return err
 		}
@@ -230,18 +156,18 @@ func (s *Syncer) forwardAncestry(ctx context.Context, hash gethCommon.Hash, olde
 		item, _ = s.headerCache.Get(hash)
 	}
 
-	if item.forwarded {
+	if item.Forwarded {
 		return nil
 	}
 
-	if item.header.Number.Uint64() > oldestHeight {
-		err := s.forwardAncestry(ctx, item.header.ParentHash, oldestHeight)
+	if item.Header.Number.Uint64() > oldestHeight {
+		err := s.forwardAncestry(ctx, item.Header.ParentHash, oldestHeight)
 		if err != nil {
 			return err
 		}
 	}
 
-	s.headers <- item.header
-	item.forwarded = true
+	s.headers <- item.Header
+	item.Forwarded = true
 	return nil
 }

--- a/relayer/chain/ethereum/syncer/syncer_test.go
+++ b/relayer/chain/ethereum/syncer/syncer_test.go
@@ -1,0 +1,213 @@
+package syncer_test
+
+import (
+	"context"
+	"math/big"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/sirupsen/logrus"
+	"github.com/snowfork/polkadot-ethereum/relayer/chain/ethereum/syncer"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"golang.org/x/sync/errgroup"
+)
+
+func makeHeaderChain(num int, seed int64) []*types.Header {
+	r := rand.New(rand.NewSource(seed))
+	headers := make([]*types.Header, num)
+
+	for i := 0; i < num; i++ {
+		header := types.Header{
+			Number: big.NewInt(int64(i)),
+			Nonce:  types.EncodeNonce(r.Uint64()),
+		}
+		if i > 0 {
+			header.ParentHash = headers[i-1].Hash()
+		}
+		headers[i] = &header
+	}
+
+	return headers
+}
+
+type TestSubscription struct{}
+
+func (tes *TestSubscription) Unsubscribe()      {}
+func (tes *TestSubscription) Err() <-chan error { return make(chan error) }
+
+type TestHeaderLoader struct {
+	mock.Mock
+	NewHeaders chan<- *types.Header
+}
+
+func (thl *TestHeaderLoader) HeaderByHash(ctx context.Context, hash common.Hash) (*types.Header, error) {
+	args := thl.Called(hash)
+	return args.Get(0).(*types.Header), args.Error(1)
+}
+
+func (thl *TestHeaderLoader) HeaderByNumber(ctx context.Context, number *big.Int) (*types.Header, error) {
+	var args mock.Arguments
+	if number == nil {
+		args = thl.Called(nil)
+	} else {
+		args = thl.Called(*number)
+	}
+	return args.Get(0).(*types.Header), args.Error(1)
+}
+
+func (thl *TestHeaderLoader) SubscribeNewHead(ctx context.Context, ch chan<- *types.Header) (ethereum.Subscription, error) {
+	thl.NewHeaders = ch
+	return &TestSubscription{}, nil
+}
+
+func Test_HeaderCache(t *testing.T) {
+	cache := syncer.NewHeaderCache(3)
+	headers := makeHeaderChain(5, 0)
+
+	assert.True(t, cache.Insert(headers[0]))
+	assert.True(t, cache.Insert(headers[1]))
+	assert.True(t, cache.Insert(headers[2]))
+
+	// Oldest header should still be in cache
+	header0Item, exists := cache.Get(headers[0].Hash())
+	assert.True(t, exists)
+	assert.Equal(t, header0Item.Header, headers[0])
+	assert.False(t, header0Item.Forwarded)
+
+	// Re-insert an existing header
+	assert.True(t, cache.Insert(headers[0]))
+
+	// This should prune header 0 and only header 0
+	assert.True(t, cache.Insert(headers[3]))
+	header0Item, exists = cache.Get(headers[0].Hash())
+	assert.Nil(t, header0Item)
+	assert.False(t, exists)
+	header1Item, _ := cache.Get(headers[1].Hash())
+	assert.NotNil(t, header1Item)
+
+	// Cannot re-insert a pruned header
+	assert.False(t, cache.Insert(headers[0]))
+	header0Item, _ = cache.Get(headers[0].Hash())
+	assert.Nil(t, header0Item)
+
+	// Insert sibling headers
+	var header1Sib = &types.Header{
+		Number:     headers[1].Number,
+		Nonce:      types.EncodeNonce(432),
+		ParentHash: headers[1].ParentHash,
+	}
+	assert.True(t, cache.Insert(header1Sib))
+
+	// Prune multiple headers
+	assert.True(t, cache.Insert(headers[4]))
+	header1Item, _ = cache.Get(headers[1].Hash())
+	header1SibItem, _ := cache.Get(header1Sib.Hash())
+	assert.Nil(t, header1Item)
+	assert.Nil(t, header1SibItem)
+}
+
+func Test_SyncFromFinalizedHeaderWithCacheGaps(t *testing.T) {
+	eg, ctx := errgroup.WithContext(context.Background())
+	headers := makeHeaderChain(6, 0)
+	headerLoader := TestHeaderLoader{}
+	// Sets the latest header
+	headerLoader.On("HeaderByNumber", nil).Return(headers[3], nil)
+	for _, header := range headers {
+		headerLoader.On("HeaderByNumber", *header.Number).Return(header, nil)
+		headerLoader.On("HeaderByHash", header.Hash()).Return(header, nil)
+	}
+
+	headerChannel := make(chan *types.Header, 5)
+	syncer := syncer.NewSyncer(2, &headerLoader, headerChannel, logrus.NewEntry(logrus.New()))
+	syncer.StartSync(ctx, eg, 0)
+
+	// header2 is finalized and should be forwarded first
+	header2 := <-headerChannel
+	assert.Equal(t, header2, headers[1])
+	headerLoader.AssertNumberOfCalls(t, "HeaderByNumber", 2)
+	headerLoader.AssertCalled(t, "HeaderByNumber", *big.NewInt(1))
+
+	// This should trigger header 3, 4 and 5 to be forwarded. 3 and 4
+	// will be missing from cache and thus fetched using HeaderByHash
+	headerLoader.NewHeaders <- headers[4]
+	header3 := <-headerChannel
+	header4 := <-headerChannel
+	header5 := <-headerChannel
+	assert.Equal(t, header3, headers[2])
+	assert.Equal(t, header4, headers[3])
+	assert.Equal(t, header5, headers[4])
+	headerLoader.AssertNumberOfCalls(t, "HeaderByHash", 2)
+	headerLoader.AssertCalled(t, "HeaderByHash", header3.Hash())
+	headerLoader.AssertCalled(t, "HeaderByHash", header4.Hash())
+
+	// This should only forward header 6 since ancestors were
+	// forwarded above
+	headerLoader.NewHeaders <- headers[5]
+	header6 := <-headerChannel
+	assert.Equal(t, header6, headers[5])
+	headerLoader.AssertNumberOfCalls(t, "HeaderByHash", 2)
+}
+
+func Test_SyncFromUnfinalizedHeader(t *testing.T) {
+	eg, ctx := errgroup.WithContext(context.Background())
+	headers := makeHeaderChain(5, 0)
+	headerLoader := TestHeaderLoader{}
+	// Sets the latest header
+	headerLoader.On("HeaderByNumber", nil).Return(headers[3], nil)
+	for _, header := range headers {
+		headerLoader.On("HeaderByHash", header.Hash()).Return(header, nil)
+	}
+
+	headerChannel := make(chan *types.Header, 5)
+	syncer := syncer.NewSyncer(2, &headerLoader, headerChannel, logrus.NewEntry(logrus.New()))
+	syncer.StartSync(ctx, eg, 1)
+
+	// Give syncer time to determine that there aren't any finalized
+	// headers to forward
+	time.Sleep(100 * time.Millisecond)
+
+	// This should trigger header 2, 3, 4 to be forwarded (header 2 is at
+	// the syncer init height, but it must be forwarded again since
+	// the height isn't final until header 4)
+	headerLoader.NewHeaders <- headers[3]
+	header2 := <-headerChannel
+	header3 := <-headerChannel
+	header4 := <-headerChannel
+	assert.Equal(t, header2, headers[1])
+	assert.Equal(t, header3, headers[2])
+	assert.Equal(t, header4, headers[3])
+}
+
+func Test_SyncForwardsMultipleForks(t *testing.T) {
+	eg, ctx := errgroup.WithContext(context.Background())
+	headersChain1 := makeHeaderChain(5, 0)
+	headersChain2 := makeHeaderChain(5, 1)
+	headerLoader := TestHeaderLoader{}
+	// Sets the latest header
+	headerLoader.On("HeaderByNumber", nil).Return(headersChain1[3], nil)
+	headerLoader.On("HeaderByNumber", *big.NewInt(1)).Return(headersChain1[1], nil)
+	for i, _ := range headersChain1 {
+		headerLoader.On("HeaderByHash", headersChain1[i].Hash()).Return(headersChain1[i], nil)
+		headerLoader.On("HeaderByHash", headersChain2[i].Hash()).Return(headersChain2[i], nil)
+	}
+
+	headerChannel := make(chan *types.Header, 10)
+	syncer := syncer.NewSyncer(2, &headerLoader, headerChannel, logrus.NewEntry(logrus.New()))
+	syncer.StartSync(ctx, eg, 0)
+	<-headerChannel
+
+	// Forward a fork
+	headerLoader.NewHeaders <- headersChain1[4]
+	time.Sleep(100 * time.Millisecond)
+	assert.Equal(t, 3, len(headerChannel))
+
+	// Forward a different fork
+	headerLoader.NewHeaders <- headersChain2[4]
+	time.Sleep(100 * time.Millisecond)
+	assert.Equal(t, 6, len(headerChannel))
+}


### PR DESCRIPTION
This PR is a follow-up on #166 which added header forwarding from Eth -> Substrate. In this PR I'm upgrading it to track all forks (for unfinalized headers) and their forwarding state. This allows me to recursively forward ancestors of a header until we get to the finalized ancestors.

Note that recursing over all 35 unfinalized ancestors will probably only occur once. After that, we usually won't need to forward any ancestors at all (i.e. recursion depth = 1).