### PR TITLE
E2E updates: disable PoW in Substrate & use polkadot-launch

### DIFF
--- a/parachain/node/Cargo.toml
+++ b/parachain/node/Cargo.toml
@@ -74,3 +74,6 @@ artemis-runtime = { path = "../runtime" }
 
 [build-dependencies]
 substrate-build-script-utils = { git = "https://github.com/paritytech/substrate.git", branch = "rococo-v1" }
+
+[features]
+test-e2e = ["artemis-runtime/test-e2e"]

--- a/parachain/runtime/Cargo.toml
+++ b/parachain/runtime/Cargo.toml
@@ -103,3 +103,4 @@ std = [
     "artemis-token-dealer/std",
     "artemis-xcm-support/std"
 ]
+test-e2e = []

--- a/parachain/runtime/src/lib.rs
+++ b/parachain/runtime/src/lib.rs
@@ -338,9 +338,16 @@ impl bridge::Config for Runtime {
 	type AppERC20 = erc20_app::Module<Runtime>;
 }
 
+#[cfg(not(feature = "test-e2e"))]
 parameter_types! {
 	pub const DescendantsUntilFinalized: u8 = 35;
 	pub const VerifyPoW: bool = true;
+}
+
+#[cfg(feature = "test-e2e")]
+parameter_types! {
+	pub const DescendantsUntilFinalized: u8 = 0;
+	pub const VerifyPoW: bool = false;
 }
 
 impl verifier_lightclient::Config for Runtime {

--- a/test/scripts/helpers/overrideParachainSpec.js
+++ b/test/scripts/helpers/overrideParachainSpec.js
@@ -13,7 +13,7 @@ function replaceNested(data, keys, value) {
         return value;
     }
 
-    const key0 = keys[0];
+    const key0 = isNaN(parseInt(keys[0])) ? keys[0] : parseInt(keys[0]);
     if (!(key0 in data)) {
         throw Error("Key '" + key + "' not found in original spec");
     }


### PR DESCRIPTION
This PR:
* Adds a feature `test-e2e` to our Substrate runtime which disables PoW and causes Eth headers to be finalized immediately
* Launches the Substrate node using polkadot-launch in e2e tests