### PR TITLE
Relayer syncing & Substrate logging fixes for e2e tests

### DIFF
--- a/ethereum/scripts/dumpRelayerConfig.js
+++ b/ethereum/scripts/dumpRelayerConfig.js
@@ -20,6 +20,7 @@ const dump = (bridge, ethApp, erc20App) => {
     const config = {
         ethereum: {
             endpoint: "ws://localhost:9545/",
+            "descendants-until-final": 35,
             bridge: {
                 address: bridge.address,
                 abi: bridgeAbiFile,

--- a/ethereum/scripts/dumpTestConfig.js
+++ b/ethereum/scripts/dumpTestConfig.js
@@ -24,6 +24,7 @@ const dumpConfig = async (tmpDir, contracts) => {
     const config = {
         ethereum: {
             endpoint: "ws://localhost:8545/",
+            "descendants-until-final": 0,
             bridge: {
                 address: contracts.bridge.address,
                 abi: bridgeAbiFile,

--- a/parachain/pallets/verifier-lightclient/src/lib.rs
+++ b/parachain/pallets/verifier-lightclient/src/lib.rs
@@ -156,6 +156,8 @@ decl_module! {
 		pub fn import_header(origin, header: EthereumHeader, proof: Vec<EthashProofData>) -> DispatchResult {
 			let sender = ensure_signed(origin)?;
 
+			debug::RuntimeLogger::init();
+
 			debug::trace!(
 				target: "import_header",
 				"Received header {}. Starting validation",

--- a/relayer/README.md
+++ b/relayer/README.md
@@ -72,6 +72,7 @@ Or, manually create a config file using the template below:
 ```toml
 [ethereum]
 endpoint = "ws://localhost:9545/"
+descendants-until-final = 35
 
 [ethereum.bridge]
 address = "0x17f7C1e314180D8b8588CA50cF09A0e0847c77F6"

--- a/relayer/chain/ethereum/chain.go
+++ b/relayer/chain/ethereum/chain.go
@@ -95,7 +95,7 @@ func (ch *Chain) Start(ctx context.Context, eg *errgroup.Group, subInit chan<- c
 		}).Debug("Received init params for Ethereum from Substrate")
 
 		if ch.listener != nil {
-			err = ch.listener.Start(ctx, eg, uint64(ethInitHeaderID.Number))
+			err = ch.listener.Start(ctx, eg, uint64(ethInitHeaderID.Number), uint64(ch.config.DescendantsUntilFinal))
 			if err != nil {
 				return err
 			}

--- a/relayer/chain/ethereum/config.go
+++ b/relayer/chain/ethereum/config.go
@@ -1,10 +1,11 @@
 package ethereum
 
 type Config struct {
-	Endpoint   string                  `mapstructure:"endpoint"`
-	PrivateKey string                  `mapstructure:"private-key"`
-	Bridge     ContractInfo            `mapstructure:"bridge"`
-	Apps       map[string]ContractInfo `mapstructure:"apps"`
+	Endpoint              string                  `mapstructure:"endpoint"`
+	PrivateKey            string                  `mapstructure:"private-key"`
+	DescendantsUntilFinal byte                    `mapstructure:"descendants-until-final"`
+	Bridge                ContractInfo            `mapstructure:"bridge"`
+	Apps                  map[string]ContractInfo `mapstructure:"apps"`
 }
 
 type ContractInfo struct {

--- a/relayer/chain/ethereum/listener.go
+++ b/relayer/chain/ethereum/listener.go
@@ -93,7 +93,7 @@ func (li *Listener) pollEventsAndHeaders(ctx context.Context, initBlockHeight ui
 	headerSyncer := syncer.NewSyncer(35, syncer.NewHeaderLoader(li.conn.client), headers, li.log)
 
 	li.log.Info("Syncing headers starting...")
-	err := headerSyncer.StartSync(headerCtx, headerEg, initBlockHeight)
+	err := headerSyncer.StartSync(headerCtx, headerEg, initBlockHeight-1)
 	if err != nil {
 		li.log.WithError(err).Error("Failed to start header sync")
 		return err

--- a/test/scripts/start-services.sh
+++ b/test/scripts/start-services.sh
@@ -38,12 +38,12 @@ start_parachain()
 {
     echo "Starting Parachain"
     pushd ../parachain
-    bin=$(pwd)/target/debug/artemis
+    bin=$(pwd)/target/release/artemis
 
-    cargo build --features "test-e2e"
+    cargo build --release --features "test-e2e"
 
     echo "Generating Parachain spec"
-    target/debug/artemis build-spec --disable-default-bootnode > $configdir/spec.json
+    target/release/artemis build-spec --disable-default-bootnode > $configdir/spec.json
 
     echo "Inserting Ganache chain info into genesis spec"
     ethereum_initial_header=$(curl http://localhost:8545 \
@@ -53,19 +53,29 @@ start_parachain()
         | node ../test/scripts/helpers/transformEthHeader.js)
     node ../test/scripts/helpers/overrideParachainSpec.js $configdir/spec.json \
         genesis.runtime.verifierLightclient.initialDifficulty 0x0 \
-        genesis.runtime.verifierLightclient.initialHeader "$ethereum_initial_header"
+        genesis.runtime.verifierLightclient.initialHeader "$ethereum_initial_header" \
+        genesis.runtime.parachainInfo.parachainId 200 \
+        para_id 200
 
     echo "Writing Polkadot configuration"
     cp config.json $configdir/polkadotConfig.json
     parachain_conf="{
-		\"bin\": \"$bin\",
-		\"id\": \"200\",
-		\"wsPort\": 11144,
-		\"port\": 31200,
-		\"balance\": \"1000000000000000000000\",
-		\"flags\": [\"--discover-local\", \"--\", \"--execution=wasm\"],
-		\"chain\": \"$configdir/spec.json\"
-	}"
+        \"bin\": \"$bin\",
+        \"id\": \"200\",
+        \"wsPort\": 11144,
+        \"port\": 31200,
+        \"balance\": \"1000000000000000000000\",
+        \"flags\": [
+            \"-lbasic_authorship=trace,import_header=trace,runtime=debug,txpool=trace\",
+            \"--rpc-cors=all\",
+            \"--offchain-worker=Always\",
+            \"--enable-offchain-indexing=true\",
+            \"--discover-local\",
+            \"--\",
+            \"--execution=wasm\"
+        ],
+        \"chain\": \"$configdir/spec.json\"
+    }"
     node ../test/scripts/helpers/overrideParachainSpec.js $configdir/polkadotConfig.json \
         parachains.0 "$parachain_conf"
 
@@ -76,7 +86,6 @@ start_parachain()
     scripts/wait-for-it.sh -t 20 localhost:11144
     sleep 5
 
-    echo "Parachain PID: $!"
 }
 
 start_relayer()
@@ -107,13 +116,16 @@ start_relayer
 echo "Process Tree:"
 pstree $$
 
+sleep 3
 until $(grep "Syncing headers starting..." $(pwd)/relay.log > /dev/null); do
     echo "Waiting for relayer to generate DAG cache..."
     sleep 20
 done
 
-echo "Waiting for relayer to sync headers..."
-sleep 10
+until $(grep "Done retrieving finalized headers" $(pwd)/relay.log > /dev/null); do
+    echo "Waiting for relayer to sync headers..."
+    sleep 5
+done
 
 echo "System has been initialized and E2E tests can be executed"
 


### PR DESCRIPTION
This PR has small logging and syncing fixes. After this, you can confirm that header syncing in Eth -> Sub direction is working by looking for these entries in the parachain log output:
```bash
2021-01-18 20:32:54.406  TRACE tokio-runtime-worker [Relaychain] import_header:Received header 49. Starting validation    
2021-01-18 20:32:54.418  TRACE tokio-runtime-worker [Relaychain] import_header:Validation succeeded. Starting import of header 49    
2021-01-18 20:32:54.419  TRACE tokio-runtime-worker [Relaychain] import_header:Import of header 49 succeeded!
```

Note that relayer logs can't tell you whether a transaction has been successfully processed in Substrate.