### PR TITLE
Relayer command to get Eth genesis block for parachain spec

### DIFF
--- a/parachain/README.md
+++ b/parachain/README.md
@@ -49,6 +49,20 @@ Follow the [Setup](../ethereum/README.md#set-up) guide to do this.
 
 For a fully operational chain, further configuration may be required.
 
+#### Ethereum Genesis Block
+
+The parachain needs to be synced with the Ethereum chain before it can verify and dispatch Ethereum events. To bootstrap / sync the
+parachain quickly, it's advisable to set a newly finalized Ethereum block in the chain spec.
+
+To get a newly finalized Ethereum block in a format compatible with Substrate's chain spec, use the `getblock` relayer command:
+```bash
+cd ../relayer
+# Alternatively, use '--format rust' to get the Rust code
+build/artemis-relay getblock --config /tmp/relay-config.toml --format json
+```
+
+Insert the output of the `getblock` command in the `initial_header` field in the `verifier_lightclient` section of the chain spec.
+
 #### Ethereum Contract Addresses
 
 Each application module (ETH, ERC20) within the parachain must be configured with the contract address for its peer application on the Ethereum side. These addresses are included in Genesis storage via the chain spec.

--- a/relayer/cmd/getblock.go
+++ b/relayer/cmd/getblock.go
@@ -1,0 +1,198 @@
+// Copyright 2020 Snowfork
+// SPDX-License-Identifier: LGPL-3.0-only
+
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	gethTypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/snowfork/polkadot-ethereum/relayer/chain/ethereum"
+	"github.com/snowfork/polkadot-ethereum/relayer/core"
+)
+
+type Format string
+
+const (
+	RustFmt Format = "rust"
+	JSONFmt Format = "json"
+)
+
+func getBlockCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "getblock",
+		Short:   "Retrieve the latest finalized block",
+		Args:    cobra.ExactArgs(0),
+		Example: "artemis-relay getblock",
+		RunE:    GetBlockFn,
+	}
+	cmd.Flags().StringP(
+		"format",
+		"f",
+		"rust",
+		"The output format. Options are 'rust' and 'json'. They correspond to the Substrate genesis config formats.",
+	)
+	return cmd
+}
+
+func GetBlockFn(cmd *cobra.Command, _ []string) error {
+	config, err := core.LoadConfig()
+	if err != nil {
+		return err
+	}
+
+	format := Format(cmd.Flags().Lookup("format").Value.String())
+
+	header, err := getEthBlock(&config.Eth)
+	if err != nil {
+		return err
+	}
+
+	return printEthBlockForSub(header, format)
+}
+
+func getEthBlock(config *ethereum.Config) (*gethTypes.Header, error) {
+	ctx := context.Background()
+	client, err := ethclient.Dial(config.Endpoint)
+	if err != nil {
+		return nil, err
+	}
+	defer client.Close()
+
+	chainID, err := client.NetworkID(ctx)
+	logrus.WithFields(logrus.Fields{
+		"endpoint": config.Endpoint,
+		"chainID":  chainID,
+	}).Info("Connected to chain")
+
+	latestHeader, err := client.HeaderByNumber(ctx, nil)
+	header, err := client.HeaderByNumber(
+		ctx,
+		new(big.Int).Sub(latestHeader.Number, big.NewInt(int64(config.DescendantsUntilFinal))),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return header, nil
+}
+
+func printEthBlockForSub(header *gethTypes.Header, format Format) error {
+	headerForSub, err := ethereum.MakeHeaderData(header)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println("")
+	if format == RustFmt {
+		fmt.Printf(
+			`EthereumHeader {
+			parent_hash: hex!("%x").into(),
+			timestamp: %du64.into(),
+			number: %du64.into(),
+			author: hex!("%x").into(),
+			transactions_root: hex!("%x").into(),
+			ommers_hash: hex!("%x").into(),
+			extra_data: hex!("%x").into(),
+			state_root: hex!("%x").into(),
+			receipts_root: hex!("%x").into(),
+			logs_bloom: (&hex!("%x")).into(),
+			gas_used: %du64.into(),
+			gas_limit: %du64.into(),
+			difficulty: %du64.into(),
+			seal: vec![
+				hex!("%x").to_vec(),
+				hex!("%x").to_vec(),
+			],
+		}`,
+			headerForSub.ParentHash,
+			header.Time,
+			headerForSub.Number,
+			headerForSub.Author,
+			headerForSub.TransactionsRoot,
+			headerForSub.OmmersHash,
+			headerForSub.ExtraData,
+			headerForSub.StateRoot,
+			headerForSub.ReceiptsRoot,
+			headerForSub.LogsBloom,
+			headerForSub.GasUsed,
+			headerForSub.GasLimit,
+			headerForSub.Difficulty,
+			headerForSub.Seal[0],
+			headerForSub.Seal[1],
+		)
+		fmt.Println("")
+	} else {
+		extraData, err := json.Marshal(bytesAsArray64(headerForSub.ExtraData))
+		if err != nil {
+			return err
+		}
+		logsBloom, err := json.Marshal(headerForSub.LogsBloom)
+		if err != nil {
+			return err
+		}
+		seal1, err := json.Marshal(bytesAsArray64(headerForSub.Seal[0]))
+		if err != nil {
+			return err
+		}
+		seal2, err := json.Marshal(bytesAsArray64(headerForSub.Seal[1]))
+		if err != nil {
+			return err
+		}
+
+		fmt.Printf(
+			`{
+			"parent_hash": "%s",
+			"timestamp": %d,
+			"number": %d,
+			"author": "%s",
+			"transactions_root": "%s",
+			"ommers_hash": "%s",
+			"extra_data": %s,
+			"state_root": "%s",
+			"receipts_root": "%s",
+			"logs_bloom": %s,
+			"gas_used": "%#x",
+			"gas_limit": "%#x",
+			"difficulty": "%#x",
+			"seal": [
+				%s,
+				%s
+			]
+		}`,
+			headerForSub.ParentHash.Hex(),
+			header.Time,
+			headerForSub.Number,
+			headerForSub.Author.Hex(),
+			headerForSub.TransactionsRoot.Hex(),
+			headerForSub.OmmersHash.Hex(),
+			extraData,
+			headerForSub.StateRoot.Hex(),
+			headerForSub.ReceiptsRoot.Hex(),
+			logsBloom,
+			headerForSub.GasUsed,
+			headerForSub.GasLimit,
+			headerForSub.Difficulty,
+			seal1,
+			seal2,
+		)
+		fmt.Println("")
+	}
+
+	return nil
+}
+
+func bytesAsArray64(bytes []byte) []uint64 {
+	arr := make([]uint64, len(bytes))
+	for i, v := range bytes {
+		arr[i] = uint64(v)
+	}
+	return arr
+}

--- a/relayer/cmd/root.go
+++ b/relayer/cmd/root.go
@@ -25,6 +25,7 @@ func init() {
 	cobra.OnInitialize(initConfig)
 	rootCmd.PersistentFlags().StringVar(&configFile, "config", "", "config file")
 	rootCmd.AddCommand(runCmd())
+	rootCmd.AddCommand(getBlockCmd())
 }
 
 func initConfig() {

--- a/relayer/core/relay.go
+++ b/relayer/core/relay.go
@@ -48,7 +48,7 @@ type Config struct {
 }
 
 func NewRelay() (*Relay, error) {
-	config, err := loadConfig()
+	config, err := LoadConfig()
 	if err != nil {
 		return nil, err
 	}
@@ -167,7 +167,7 @@ func (re *Relay) Start() {
 	re.subChain.Stop()
 }
 
-func loadConfig() (*Config, error) {
+func LoadConfig() (*Config, error) {
 	var config Config
 	err := viper.Unmarshal(&config)
 	if err != nil {


### PR DESCRIPTION
The relayer currently forwards headers one by one, from the newest finalized known to the parachain to the latest Ethereum block. This can take days. Now that we're using `polkadot-launch`, the relayer also seems to overwhelm the parachain easily when syncing thousands of old blocks, i.e. transactions stop being processed when the transaction pool is full (??). For now, it's best to avoid long syncs by setting a new Eth header in the parachain's genesis spec.

PS. I haven't figured out the exact mechanism of this "overwhelment" yet. Are new transactions from the relayer ignored when the transaction pool is full or are old transactions dropped? why doesn't the client library return an error?