### PR TITLE
Force relayer shutdown if deadlock detected

### DIFF
--- a/relayer/chain/substrate/writer.go
+++ b/relayer/chain/substrate/writer.go
@@ -100,6 +100,7 @@ func (wr *Writer) writeLoop(ctx context.Context) error {
 					"blockNumber": header.HeaderData.(ethereum.Header).Number,
 					"error":       err,
 				}).Error("Failure submitting header to substrate")
+				return err
 			}
 		}
 	}
@@ -201,6 +202,9 @@ func (wr *Writer) WriteHeader(ctx context.Context, header *chain.Header) error {
 				"error":       err,
 				"retries":     retries,
 			}).Error("Failure submitting header to substrate")
+			if retries >= 4 {
+				return err
+			}
 		} else {
 			break
 		}


### PR DESCRIPTION
I spent some time thinking about how we can make the relayer shut down without any deadlocks. This can happen when the channel consumer (the writer) shuts down before the producer (the listener), and the producer then blocks while trying to send something via an already-full channel. There are 3 approaches I considered, and this PR implements no. 3:
1. Shut the listener / producer down before the writer / consumer
  * This complicates the coordination between producer + consumer. You'd probably need 2 signals to shut down in 2 stages. But you'd only need to implement this logic once.
2. Always use non-blocking channel sends
  * Each channel send will become bloated with this boilerplate - highly likely someone will forget to add this at some point:
```golang
for {
  select {
  case <-ctx.Done():
	  return
  case li.messages <- chunk:
	  break
  case <-time.After(100 * time.Millisecond):
  }
}
```
3. Detect a deadlock and kill the process
  * This is the easiest and probably fine since we're not persisting state between runs