### PR TITLE
Always restart relayer

### DIFF
--- a/infra/ansible/templates/relay.service.j2
+++ b/infra/ansible/templates/relay.service.j2
@@ -7,7 +7,7 @@ Wants=network-online.target
 Environment=ARTEMIS_ETHEREUM_KEY={{ keys.ethereum }}
 Environment=ARTEMIS_SUBSTRATE_KEY={{ keys.substrate }}
 ExecStart=/usr/local/bin/artemis-relay run --config /etc/artemis-relay/config.toml
-Restart=on-failure
+Restart=always
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
The relayer can exit due to an error with exit code 0 right now. So we can't rely on the exit code for restarts. But I'm not sure we want to rely on the exit code regardless - the relayer should always be up, right?