### PR TITLE
WIP: access struct's serialized bytes directly

### DIFF
--- a/ethereum/contracts/IncentivizedReceiveChannel.sol
+++ b/ethereum/contracts/IncentivizedReceiveChannel.sol
@@ -143,4 +143,18 @@ contract IncentivizedReceiveChannel {
         }
         return keccak256(contents) == commitment.commitmentHash;
     }
+
+    function testCommitment(
+        Commitment memory commitment,
+        CommitmentContents memory commitmentContents
+    ) public returns (bytes memory) {
+        return abi.encode(commitmentContents.messages);
+    }
+
+    function testCommitmentHash(
+        Commitment memory commitment,
+        CommitmentContents memory commitmentContents
+    ) public returns (bytes32) {
+        return keccak256(abi.encode(commitmentContents.messages));
+    }
 }


### PR DESCRIPTION
Current commitment validation:
```solidity
abi.encodePacked(
                    commitmentContents.messages[i].nonce,
                    commitmentContents.messages[i].senderApplicationId,
                    commitmentContents.messages[i].targetApplicationAddress,
                    commitmentContents.messages[i].payload
);
contents = abi.encodePacked(contents, temp);
commitmentHash = keccak256(contents);
```

We can potentially avoid accessing each messages' fields by updating the commitment hash:
```solidity
keccak256(abi.encode(commitmentContents.messages));
```

The additional test case demonstrates the desired functionality. Right now the test suite isn't properly hashing the encoded bytes, even though the two sets of bytes are the same.