### PR TITLE
Minor fixes for relayer

### DIFF
--- a/relayer/chain/ethereum/listener.go
+++ b/relayer/chain/ethereum/listener.go
@@ -111,6 +111,11 @@ func (li *Listener) pollEventsAndHeaders(
 				li.log.Info("Not polling events since channel is nil")
 			}
 
+			// Don't attempt to forward events prior to genesis block
+			if descendantsUntilFinal > gethheader.Number.Uint64() {
+				continue
+			}
+
 			finalizedBlockNumber := gethheader.Number.Uint64() - descendantsUntilFinal
 			var events []*outbound.ContractMessage
 

--- a/relayer/cmd/fetch_messages.go
+++ b/relayer/cmd/fetch_messages.go
@@ -33,7 +33,7 @@ func fetchMessagesCmd() *cobra.Command {
 		Use:     "fetch-messages",
 		Short:   "Retrieve the messages specified by block and index",
 		Args:    cobra.ExactArgs(0),
-		Example: "artemis-relay getmessages -b 812e7d414071648252bb3c2dc9c6d2f292fb615634606f9251191c7372eb4acc -i 123",
+		Example: "artemis-relay fetch-messages -b 812e7d414071648252bb3c2dc9c6d2f292fb615634606f9251191c7372eb4acc -i 123",
 		RunE:    FetchMessagesFn,
 	}
 	cmd.Flags().StringP("block", "b", "", "Block hash")


### PR DESCRIPTION
This should solve https://github.com/Snowfork/polkadot-ethereum/issues/256

@vgeddes you mentioned that you saw segfaults relating to #256. I didn't see those, but I saw error logs relating to underflow:
```bash
time="2021-02-05T14:08:34-08:00" level=error msg="Failure fetching event logs" chain=Ethereum error="Number can only safely store up to 53 bits"
```
You might have seen a segfault right at the end if the relayer crashed, but usually the root cause isn't the segfault - the segfault is a symptom of deallocation that happens in the wrong order during shutdown. The segfault is tricky to fix but harmless. If you experience an issue, also have a look at the logs prior to shutdown