### PR TITLE
Relayer tracks extrinsic status

### DIFF
--- a/relayer/chain/substrate/mortal_era.go
+++ b/relayer/chain/substrate/mortal_era.go
@@ -1,0 +1,34 @@
+// Copyright 2020 Snowfork
+// SPDX-License-Identifier: LGPL-3.0-only
+
+package substrate
+
+import (
+	"math"
+
+	"github.com/snowfork/go-substrate-rpc-client/v2/types"
+)
+
+// Must be a power of two between 4 and 65536 (inclusive)
+const MortalEraPeriod = uint64(64)
+
+func NewMortalEra(currentBlockNumber uint64) types.ExtrinsicEra {
+	// Adapted from https://substrate.dev/rustdocs/v2.0.1/src/sp_runtime/generic/era.rs.html#66
+	phase := currentBlockNumber % MortalEraPeriod
+
+	quantizeFactor := MortalEraPeriod >> 12
+	if quantizeFactor < 1 {
+		quantizeFactor = 1
+	}
+	quantizedPhase := phase / quantizeFactor * quantizeFactor
+
+	encoded := uint16(math.Log2(float64(MortalEraPeriod))-1) | uint16((quantizedPhase/quantizeFactor)<<4)
+
+	return types.ExtrinsicEra{
+		IsMortalEra: true,
+		AsMortalEra: types.MortalEra{
+			First:  byte(encoded),
+			Second: byte(encoded >> 8),
+		},
+	}
+}

--- a/relayer/chain/substrate/mortal_era_test.go
+++ b/relayer/chain/substrate/mortal_era_test.go
@@ -1,0 +1,25 @@
+// Copyright 2020 Snowfork
+// SPDX-License-Identifier: LGPL-3.0-only
+
+package substrate_test
+
+import (
+	"testing"
+
+	"github.com/snowfork/polkadot-ethereum/relayer/chain/substrate"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMortalEra(t *testing.T) {
+	era := substrate.NewMortalEra(1)
+	assert.Equal(t, era.AsMortalEra.First, byte(21))
+	assert.Equal(t, era.AsMortalEra.Second, byte(0))
+
+	era = substrate.NewMortalEra(63)
+	assert.Equal(t, era.AsMortalEra.First, byte(245))
+	assert.Equal(t, era.AsMortalEra.Second, byte(3))
+
+	era = substrate.NewMortalEra(64)
+	assert.Equal(t, era.AsMortalEra.First, byte(5))
+	assert.Equal(t, era.AsMortalEra.Second, byte(0))
+}

--- a/relayer/chain/substrate/outgoing_extrinsics.go
+++ b/relayer/chain/substrate/outgoing_extrinsics.go
@@ -1,0 +1,101 @@
+// Copyright 2020 Snowfork
+// SPDX-License-Identifier: LGPL-3.0-only
+
+package substrate
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/snowfork/go-substrate-rpc-client/v2/types"
+	"golang.org/x/sync/errgroup"
+)
+
+const MaxWatchedExtrinsics = 100
+
+type extrinsicPool struct {
+	sync.Mutex
+	conn    *Connection
+	eg      *errgroup.Group
+	log     *logrus.Entry
+	watched uint
+}
+
+func newExtrinsicPool(eg *errgroup.Group, conn *Connection, log *logrus.Entry) *extrinsicPool {
+	ep := extrinsicPool{
+		conn:    conn,
+		eg:      eg,
+		log:     log,
+		watched: 0,
+	}
+	return &ep
+}
+
+func (ep *extrinsicPool) WaitForSubmitAndWatch(ctx context.Context, ext *types.Extrinsic) {
+	defer ep.Unlock()
+
+	for {
+		ep.Lock()
+		if ep.hasCapacity() {
+			ep.eg.Go(func() error {
+				return ep.submitAndWatchLoop(ctx, ext)
+			})
+
+			ep.watched++
+			return
+		}
+		ep.Unlock()
+
+		time.Sleep(100 * time.Millisecond)
+	}
+}
+
+func (ep *extrinsicPool) hasCapacity() bool {
+	return ep.watched < MaxWatchedExtrinsics
+}
+
+func (ep *extrinsicPool) submitAndWatchLoop(ctx context.Context, ext *types.Extrinsic) error {
+	sub, err := ep.conn.api.RPC.Author.SubmitAndWatchExtrinsic(*ext)
+	if err != nil {
+		return err
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("Context was canceled. Stopping extrinsic monitoring")
+		case status := <-sub.Chan():
+			ep.logStatusUpdate(status)
+
+			// Indicates that the extrinsic wasn't processed. We need to retry
+			if status.IsDropped || status.IsInvalid {
+				sub.Unsubscribe()
+				newSub, err := ep.conn.api.RPC.Author.SubmitAndWatchExtrinsic(*ext)
+				if err != nil {
+					return err
+				}
+				sub = newSub
+			} else if !status.IsReady && !status.IsFuture && !status.IsBroadcast {
+				// We assume all other status codes indicate that the extrinsic was processed
+				// and account nonce was incremented.
+				// See details at:
+				// https://github.com/paritytech/substrate/blob/29aca981db5e8bf8b5538e6c7920ded917013ef3/primitives/transaction-pool/src/pool.rs#L56-L127
+				sub.Unsubscribe()
+				ep.Lock()
+				defer ep.Unlock()
+				ep.watched--
+				return nil
+			}
+		case err := <-sub.Err():
+			return err
+		}
+	}
+}
+
+func (ep *extrinsicPool) logStatusUpdate(status types.ExtrinsicStatus) {
+	statusBytes, _ := status.MarshalJSON()
+	ep.log.WithField("status", string(statusBytes)).Debug("Received extrinsic status update")
+}

--- a/relayer/chain/substrate/writer_test.go
+++ b/relayer/chain/substrate/writer_test.go
@@ -47,9 +47,9 @@ func TestWrite(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	message := chainTypes.Message{}
+	message := chain.EthereumOutboundMessage(chainTypes.Message{})
 
-	err = writer.WriteMessages(ctx, []chain.EthereumOutboundMessage{chain.EthereumOutboundMessage(message)})
+	err = writer.WriteMessages(ctx, []*chain.EthereumOutboundMessage{&message})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/relayer/core/relay.go
+++ b/relayer/core/relay.go
@@ -172,7 +172,7 @@ func (re *Relay) Start() {
 		break
 	case <-ctx.Done():
 		// Goroutines are either shutting down or deadlocked.
-		// Give them a second...
+		// Give them a few seconds...
 		select {
 		case <-time.After(3 * time.Second):
 			break

--- a/relayer/core/relay.go
+++ b/relayer/core/relay.go
@@ -174,7 +174,7 @@ func (re *Relay) Start() {
 		// Goroutines are either shutting down or deadlocked.
 		// Give them a second...
 		select {
-		case <-time.After(time.Second):
+		case <-time.After(3 * time.Second):
 			break
 		case _, stillWaiting := <-notifyWaitDone:
 			if !stillWaiting {


### PR DESCRIPTION
This PR improves the situation where extrinsics are occasionally dropped in Substrate. It's not a complete solution, but it does make the relayer behave in a way that's easier to manage. The two key improvements:
1. The relayer implicitly rate limits by restricting the "in flight" extrinsics to `MaxWatchedExtrinsics`. This should prevent dropped transactions (not invalid ones though).
2. It retries all extrinsics, not just headers, after a grace period. If a retry fails, it crashes. This is a bit harsh but it's unlikely that a retry will succeed without giving the Substrate node substantial time to resolve whatever is going wrong, e.g. [a transaction ban only resolves after 30 minutes](https://stackoverflow.com/questions/57270007/in-substrate-what-does-code-1012-transaction-is-temporarily-banned-mean).

I recommend we try to restart the relayer in 10 minute intervals. The problem usually resolves itself after the 1st or 2nd restart. I know this is fine for the Eth -> Sub direction - it replays headers + events. But is this fine in the opposite direction?