### PR TITLE
Beefy relay compatibility

### DIFF
--- a/ethereum/migrations/2_next.js
+++ b/ethereum/migrations/2_next.js
@@ -26,7 +26,7 @@ const channels = {
   },
 }
 
-module.exports = function(deployer, network, accounts) {
+module.exports = function (deployer, network, accounts) {
   deployer.then(async () => {
     channels.basic.inbound.instance = await deployer.deploy(channels.basic.inbound.contract)
     channels.basic.outbound.instance = await deployer.deploy(channels.basic.outbound.contract)
@@ -62,6 +62,7 @@ module.exports = function(deployer, network, accounts) {
       },
     );
 
-    await deployer.deploy(TestToken, 100000000, "Test Token", "TEST");
+    const testSupply = '1000000' + '000000000000000000';
+    await deployer.deploy(TestToken, testSupply, "Test Token", "TEST");
   })
 };

--- a/ethereum/scripts/sendUser1.js
+++ b/ethereum/scripts/sendUser1.js
@@ -1,0 +1,19 @@
+
+const ERC20App = artifacts.require("ERC20App")
+const TestToken = artifacts.require("TestToken")
+
+module.exports = async () => {
+  const accounts = await web3.eth.getAccounts();
+
+  const account0 = accounts[0];
+  const account1 = accounts[1];
+  const testAmount = '100' + '000000000000000000';
+  const testToken = await TestToken.deployed()
+
+  const result = testToken.transfer(account1, testAmount, {
+    from: account0
+  });
+  console.log({ result });
+  const complete = await result;
+  console.log({ complete });
+}

--- a/parachain/config.json
+++ b/parachain/config.json
@@ -13,6 +13,10 @@
 				"wsPort": 9955,
 				"port": 30555
 			}
+		],
+		"flags": [
+			"--enable-offchain-indexing=true",
+			"--offchain-worker=Always"
 		]
 	},
 	"parachains": [

--- a/parachain/config.json
+++ b/parachain/config.json
@@ -6,17 +6,21 @@
 			{
 				"name": "alice",
 				"wsPort": 9944,
-				"port": 30444
+				"port": 30444,
+				"flags": [
+					"--enable-offchain-indexing=true",
+					"--offchain-worker=Always"
+				]
 			},
 			{
 				"name": "bob",
 				"wsPort": 9955,
-				"port": 30555
+				"port": 30555,
+				"flags": [
+					"--enable-offchain-indexing=true",
+					"--offchain-worker=Always"
+				]
 			}
-		],
-		"flags": [
-			"--enable-offchain-indexing=true",
-			"--offchain-worker=Always"
 		]
 	},
 	"parachains": [

--- a/parachain/config.json
+++ b/parachain/config.json
@@ -32,6 +32,7 @@
 		}
 	],
 	"simpleParachains": [],
+	"hrmpChannels": [],
 	"types": {
 		"Address": "MultiAddress",
 		"LookupSource": "MultiAddress"

--- a/relayer/chain/ethereum/message.go
+++ b/relayer/chain/ethereum/message.go
@@ -46,9 +46,10 @@ func MakeMessageFromEvent(event *outbound.ContractMessage, receiptsTrie *etrie.T
 
 	value := hex.EncodeToString(message.Data)
 	log.WithFields(logrus.Fields{
-		"payload":    value,
-		"blockHash":  message.Proof.BlockHash.Hex(),
-		"eventIndex": message.Proof.TxIndex,
+		"payload":       value,
+		"blockHash":     message.Proof.BlockHash.Hex(),
+		"eventIndex":    message.Proof.TxIndex,
+		"outboundNonce": event.Nonce,
 	}).Debug("Generated message from Ethereum log")
 
 	msg := chain.EthereumOutboundMessage(message)

--- a/test/README.md
+++ b/test/README.md
@@ -38,7 +38,7 @@ Build the beefy-filled version of polkadot:
 ```bash
 git clone -n https://github.com/paritytech/polkadot.git /tmp/polkadot
 cd /tmp/polkadot
-git checkout td-mmr # Note: This has been tested only on commit e6e77c2c. If td-mmr has become newer, then things may break.
+git checkout td-mmr-custom-rpc # Note: This has been tested only on commit ace614d9. If td-mmr has become newer, then things may break.
 cargo build --release --features=real-overseer
 ```
 

--- a/test/README.md
+++ b/test/README.md
@@ -10,9 +10,10 @@ The E2E tests run against local deployments of the parachain, relayer and ganach
    ```bash
    yarn global add truffle
    (cd ../ethereum && yarn install)
-    ```
+   ```
+
 3. Development environment for Relayer. See relayer [requirements](../relayer/README.md#requirements).
-4. `timeout` - native package on Ubuntu, on macOS try ```brew install coreutils```
+4. `timeout` - native package on Ubuntu, on macOS try `brew install coreutils`
 
 ## Setup
 
@@ -20,6 +21,9 @@ Download dependencies:
 
 ```bash
 yarn install
+
+# Build typescript bindings
+cd ./node_modules/@snowfork/snowbridge-types && yarn install
 ```
 
 Install our beefy-compatible fork of `polkadot-launch`:
@@ -79,7 +83,7 @@ In the substrate webapp (linked above), you should see an `Eth.Minted` event in 
 
 #### Burning PolkaETH to unlock ETH on Ethereum
 
-To see the PolkaETH  balance for `//Alice`:
+To see the PolkaETH balance for `//Alice`:
 
 1. Navigate to Developer > Chain state > Storage
 2. Select the `assets` module in the drop-down.
@@ -113,6 +117,6 @@ truffle exec scripts/getEthBalance.js 0xBe68fC2d8249eb60bfCf0e71D5A0d2F2e292c4eD
 
 The `start-services.sh` script writes the following logs:
 
-* parachain.log
-* relayer.log
-* ganache.log
+- parachain.log
+- relayer.log
+- ganache.log

--- a/test/README.md
+++ b/test/README.md
@@ -22,18 +22,23 @@ Download dependencies:
 yarn install
 ```
 
-Install `polkadot-launch`:
+Install our beefy-compatible fork of `polkadot-launch`:
 
 ```bash
-yarn global add polkadot-launch
+git clone -n https://github.com/snowfork/polkadot-launch.git /tmp/polkadot-launch
+cd /tmp/polkadot-launch
+git checkout beefy
+yarn install
+yarn build
+yarn global add file:$(pwd)
 ```
 
-Build polkadot:
+Build the beefy-filled version of polkadot:
 
 ```bash
 git clone -n https://github.com/paritytech/polkadot.git /tmp/polkadot
 cd /tmp/polkadot
-git checkout rococo-v1
+git checkout td-mmr # Note: This has been tested only on commit e6e77c2c. If td-mmr has become newer, then things may break.
 cargo build --release --features=real-overseer
 ```
 

--- a/test/scripts/helpers/subscribeBeefyJustifications.js
+++ b/test/scripts/helpers/subscribeBeefyJustifications.js
@@ -36,9 +36,17 @@ async function start() {
       MMRProof: {
         blockHash: 'BlockHash',
         leaf: 'Vec<u8>',
-        proof: 'Vec<u8>',
+        proof: 'ActualMMRProof',
       },
       BlockHash: 'H256',
+      ActualMMRProof: {
+        /// The index of the leaf the proof is for.
+        leaf_index: 'u64',
+        /// Number of leaves in MMR, when the proof was generated.
+        leaf_count: 'u64',
+        /// Proof elements (hashes of siblings of inner nodes on the path to the leaf).
+        items: 'Vec<Hash>',
+      },
       MMRLeaf: {
         parent_number_and_hash: 'ParentNumberAndHash',
         parachainHeads: 'H256',
@@ -141,8 +149,8 @@ async function getMMRLeafForBlock(blockNumber, api) {
   const mmrProof = await api.rpc.mmr.generateProof(blockNumber);
   console.log({ mmrProof: mmrProof.toString() });
 
-  mmrLeaf = api.createType('MMRLeaf', mmrProof.leaf.toHex());
-  console.log({ mmrLeafDec: mmrLeaf.toString() })
+  decodedLeaf = api.createType('MMRLeaf', mmrProof.leaf.toHex());
+  console.log({ decodedLeaf: decodedLeaf.toString() })
 }
 
 start();

--- a/test/scripts/helpers/subscribeBeefyJustifications.js
+++ b/test/scripts/helpers/subscribeBeefyJustifications.js
@@ -7,9 +7,11 @@
 
 const { ApiPromise, WsProvider } = require('@polkadot/api');
 const WebSocket = require('ws');
-const { ethereumEncode } = require("@polkadot/util-crypto");
+const { base58Decode, addressToEvm, secp256k1Expand, secp256k1Compress, decodeAddress, encodeAddress, ethereumEncode, blake2AsHex, keccakAsHex } = require("@polkadot/util-crypto");
+const { hexToU8a, u8aToHex, u8aToU8a } = require("@polkadot/util");
 
 const RELAY_CHAIN_RPC_ENDPOINT = 'ws://localhost:9944';
+
 async function start() {
   const wsProvider = new WsProvider(RELAY_CHAIN_RPC_ENDPOINT);
   const api = await ApiPromise.create({
@@ -17,38 +19,93 @@ async function start() {
     types: {
       SignedCommitment: {
         commitment: 'Commitment',
-        signatures: 'Vec<Option<Signature>>'
+        signatures: 'Vec<Option<BeefySignature>>'
       },
       Commitment: {
         payload: 'H256',
         block_number: 'BlockNumber',
         validator_set_id: 'ValidatorSetId'
       },
-      ValidatorSetId: 'u64'
+      ValidatorSetId: 'u64',
+      BeefySignature: '[u8; 65]',
+      Authorities: 'Vec<[u8; 33]>',
+    },
+    rpc: {
+      beefy: {
+        subscribeJustifications: {
+          alias: ['beefy_subscribeJustifications', 'beefy_unsubscribeJustifications'],
+          params: [],
+          type: 'SignedCommitment',
+          method: _ => console.log("qq"),
+          pubsub: [
+            'justifications',
+            'subscribeJustifications',
+            'unsubscribeJustifications'
+          ],
+        }
+      }
     }
   });
 
-  const ws = new WebSocket('ws://localhost:9955');
-  const currentAuthorities = await api.query.beefy.authorities();
-  console.log({ currentAuthorities: currentAuthorities.map(a => ethereumEncode(a)) });
+  await getAuthorities(api);
+  await subscribeJustifications(api);
+}
 
-  const startSubscriptionRPC = {
-    jsonrpc: '2.0',
-    id: 1,
-    method: "beefy_subscribeJustifications",
-  }
+async function getAuthorities(api) {
+  const authoritiesResponse = await api.query.beefy.authorities();
+  let authorities = api.createType('Authorities', authoritiesResponse);
 
-  ws.on('open', function open() {
-    ws.send(JSON.stringify(startSubscriptionRPC));
+  // Currently, there is a bug in the Javascript decoding of the authority which results in it missing the last byte
+  // For now, we just replace this with the correct ones for testing purposes, but when integrated into the relayer
+  // we'll need to ensure the authorities are decoded correctly from the actual API. See the console.log for example.
+  const correctAuthorityAlice = '0x020a1091341fe5664bfa1782d5e04779689068c916b04cb365ec3153755684d9a1';
+  const correctAuthorityBob = '0x0390084fdbf27d2b79d26a4f13f0ccd982cb755a661969143c37cbc49ef5b91f27';
+  authoritiesCorrect = [correctAuthorityAlice, correctAuthorityBob];
+  console.log({
+    authoritiesWrong: authorities.map(a => u8aToHex(a)),
+    authoritiesCorrect,
+  })
+  authorities = authoritiesCorrect;
+
+  const authoritiesEthereum = authorities.map(a => ethereumEncode(a));
+  console.log({
+    authoritiesEthereum
   });
 
-  ws.on('message', function incoming(data) {
-    jdata = JSON.parse(data);
-    if (jdata && jdata.params && jdata.params.result) {
-      console.log(api.createType('SignedCommitment', jdata.params.result).toString());
-    }
+  return authoritiesEthereum;
+}
+
+async function subscribeJustifications(api) {
+  api.rpc.beefy.subscribeJustifications(justification => {
+    const commitment = justification.commitment;
+    const commitmentBytes = commitment.toHex();
+    const hashedCommitment = blake2AsHex(commitmentBytes, 256);
+    console.log({ justification: justification.toString(), commitmentBytes, hashedCommitment });
+    getLatestMMRInJustification(justification, api)
+  });
+}
+
+async function getLatestMMRInJustification(justification, api) {
+  // Print relevant API for reference:
+  console.log({ mmr: Object.keys(api.query.mmr) })
+  console.log({ beefy: Object.keys(api.query.beefy) })
+  console.log({ mmrLeaf: Object.keys(api.query.mmrLeaf) })
+  const blockNumber = justification.commitment.block_number.toString();
+  const mmrRoot = justification.commitment.payload.toString();
+  console.log({
+    blockNumber,
+    mmrRoot
   });
 
+  latestMMRLeaf = getMMRLeafForBlock(blockNumber, api)
+
+  // TODO Extract para_heads from MMR
+  // TODO Get proof and para_head of our parachain in para_heads
+}
+
+async function getMMRLeafForBlock(bblockNumberlock, api) {
+  // TODO query offchain storage for that MMRLeaf
+  // TODO print that MMRLeaf
 }
 
 start();

--- a/test/scripts/helpers/subscribeBeefyJustifications.js
+++ b/test/scripts/helpers/subscribeBeefyJustifications.js
@@ -201,6 +201,13 @@ async function getParaHeadData(paraHead) {
   console.log({ truncatedHead })
   const headData = await parachainApi.rpc.chain.getHeader(truncatedHead);
   console.log({ headData: headData.toHuman() });
+
+  const headerLogs = headData.toJSON().digest && headData.toJSON().digest.logs;
+  const commitmentLog = headerLogs && headerLogs[0];
+  if (commitmentLog) {
+    console.log("Got new commitment: ");
+    console.log({ commitmentLog });
+  }
 }
 
 start();

--- a/test/src/ethclient/index.js
+++ b/test/src/ethclient/index.js
@@ -6,6 +6,8 @@ const ERC20App = require('../../../ethereum/build/contracts/ERC20App.json');
 const ERC20 = require('../../../ethereum/build/contracts/ERC20.json');
 const TestToken = require('../../../ethereum/build/contracts/TestToken.json');
 
+const INCENTIVIZED_CHANNEL_ID = 1;
+
 /**
  * The Ethereum client for Bridge interaction
  */
@@ -58,7 +60,7 @@ class EthClient {
   async lockETH(from, amount, polkadotRecipient) {
     const recipientBytes = Buffer.from(polkadotRecipient.replace(/^0x/, ""), 'hex');
 
-    let receipt = await this.appETH.methods.lock(recipientBytes, 0).send({
+    let receipt = await this.appETH.methods.lock(recipientBytes, INCENTIVIZED_CHANNEL_ID).send({
       from: from,
       gas: 500000,
       value: this.web3.utils.toBN(amount)
@@ -81,7 +83,7 @@ class EthClient {
   async lockERC20(from, amount, polkadotRecipient) {
     const recipientBytes = Buffer.from(polkadotRecipient.replace(/^0x/, ""), 'hex');
 
-    return await this.appERC20.methods.lock(this.TestTokenAddress, recipientBytes, this.web3.utils.toBN(amount), 0)
+    return await this.appERC20.methods.lock(this.TestTokenAddress, recipientBytes, this.web3.utils.toBN(amount), INCENTIVIZED_CHANNEL_ID)
       .send({
         from,
         gas: 500000,

--- a/test/test/test.js
+++ b/test/test/test.js
@@ -47,7 +47,7 @@ describe('Bridge', function () {
 
       const { gasCost } = await ethClient.lockETH(account, amount, polkadotRecipient);
 
-      await sleep(50000);
+      await sleep(70000);
 
       const afterEthBalance = await ethClient.getEthBalance(account);
       const afterSubBalance = await subClient.queryAccountBalance(polkadotRecipientSS58, this.ethAssetId);
@@ -95,7 +95,7 @@ describe('Bridge', function () {
       await ethClient.approveERC20(account, amount);
       await ethClient.lockERC20(account, amount, polkadotRecipient);
 
-      await sleep(50000);
+      await sleep(70000);
 
       let afterEthBalance = await ethClient.getErc20Balance(account);
       let afterSubBalance = await subClient.queryAccountBalance(polkadotRecipientSS58, this.erc20AssetId);

--- a/test/test/test.js
+++ b/test/test/test.js
@@ -15,7 +15,7 @@ const { expect } = require("chai")
 const networkID = '344';
 const TestTokenAddress = TestToken.networks[networkID].address;
 
-describe('Bridge', function () {
+describe('Incentivized Bridge', function () {
 
   let ethClient;
   let subClient;
@@ -47,7 +47,7 @@ describe('Bridge', function () {
 
       const { gasCost } = await ethClient.lockETH(account, amount, polkadotRecipient);
 
-      await sleep(70000);
+      await sleep(40000);
 
       const afterEthBalance = await ethClient.getEthBalance(account);
       const afterSubBalance = await subClient.queryAccountBalance(polkadotRecipientSS58, this.ethAssetId);
@@ -95,7 +95,7 @@ describe('Bridge', function () {
       await ethClient.approveERC20(account, amount);
       await ethClient.lockERC20(account, amount, polkadotRecipient);
 
-      await sleep(70000);
+      await sleep(40000);
 
       let afterEthBalance = await ethClient.getErc20Balance(account);
       let afterSubBalance = await subClient.queryAccountBalance(polkadotRecipientSS58, this.erc20AssetId);


### PR DESCRIPTION
This PR adds support for running a relay chain with the beefy pallet support. All e2e tests still pass.

Related:
 - Using polkadot-launch from: https://github.com/paritytech/polkadot-launch/pull/62
 - Using polkadot from: https://github.com/paritytech/polkadot/pull/2101

We may not want to merge this to main yet, as eventually the above 2 PRs will be part of polkadot-launch/polkadot master, but I do think the team and staging and all future PRs should base themselves off this and work to maintain compatibility with this.

@denalimarsh @philipstanislaus This PR also includes a node script (subscribeBeefyJustifications), which, if you run it after everything is setup, will connect to the appropriate RPC endpoints on the relay chain and parachain and subscribe to all the data we'll need to be relayed into the Solidity light client. This script should help make it easy to integrate all the endpoints and relaying of all data types into our Golang relayer. It includes:
 1 - Getting initial list of authorities (note: currently a small bug, so hardcoded)
 2 - Getting each new beefy commitment produced and the collection of signatures on that commitment (which we need for the Relay Chain Light Client)
 3 - Getting the latest new MMR block that the beefy commitment commits to, which we need to process the commitment for validator set updates/epoch changes/new parachain headers and the proof for that MMR
 4 (WIP/TODO) - Getting the parachain heads commitment in that MMR, a merkle proof of our parachain's new head within parachain heads, and the new head data itself

Note: I had a minor issue building the suggested branch of Polkadot with an error related to `polkadot-node-primitives`. If you encounter this, you can fix it by deleting the redundant `node-primitives` line from `node/network/statement-distribution/Cargo.toml`