### PR TITLE
Update README for E2E tests

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -11,8 +11,10 @@ The E2E tests run against local deployments of the parachain, relayer and ganach
    yarn global add truffle
    (cd ../ethereum && yarn install)
     ```
+
 3. Development environment for Relayer. See relayer [requirements](../relayer/README.md#requirements).
 4. `timeout` - native package on Ubuntu, on macOS try ```brew install coreutils```
+5. Build the `@snowfork/snowbridge-types` package using these [steps](../types/README.md#development).
 
 ## Setup
 
@@ -55,7 +57,7 @@ yarn test
 
 Make sure to setup the E2E stack as described above.
 
-For interacting with Substrate, open [https://polkadot.js.org/apps/](https://polkadot.js.org/apps/?rpc=ws%3A%2F%2Flocalhost%3A11144&types=eNplkttOwkAQhl%2FF7JUmvZAqhKAhASUpCRCj4I0hZtkOsKHdafZgUNJ3d4YWOXi1OzP%2FfLtz2IlemlpwTnTEOGReH8xIjBA3oXjDYBX8jz6tpTGQDVPR2YlPMCHnS186rUTHhCyLxNAoMF5%2F6R8gFfvKMhJjypcrmCBFCRta90SrnRVNHdEnz0TCnKQcQZyRSi8p8A7qMbS7JC0s4pI8L%2FuTxNWFpIsM1SaRbk3RJG62SOy3Q5PClsl3Mdk17ZpxNbIbXZ1aN4wc%2BDVYCHkCMgXL7EJaKvgCrnNwXubFX63UqgXra1MGv0Y2k0brlhOsNE4qr9G4V0R%2FRGGeg3XneNiS%2FvmyfHrQw3myBQW68BfIDFf9DJFmJ6ozEivpZo4HJmaVhhwjnWvOqj2pXi61on34PvocyKz%2Bw6FLdZPov%2FvuV7%2FkYa0mmAJv3EfSbMQPV%2FH8ZGScnTRiqoPS68%2FRhrE6tEnbbM050nMO%2FMX2DabJYfemuAFzaGpZlr%2BYV%2Bf6) in your browser (Make sure to use this link specifically).
+For interacting with Substrate, open [https://polkadot.js.org/apps/](https://polkadot.js.org/apps/?rpc=ws%3A%2F%2Flocalhost%3A11144#/explorer) in your browser (Make sure to use this link specifically).
 
 #### Locking up ETH to mint PolkaETH on Substrate
 

--- a/test/package.json
+++ b/test/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "@polkadot/api": "^3.8.1",
-    "@snowfork/snowbridge-types": "file:../types",
+    "@snowfork/snowbridge-types": "link:../types",
     "bignumber.js": "^9.0.0",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",

--- a/test/yarn.lock
+++ b/test/yarn.lock
@@ -595,8 +595,9 @@
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.14.0.tgz#9fb3a3cf3132328151f353de4632e01e52102bea"
   integrity sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==
 
-"@snowfork/snowbridge-types@file:../types":
-  version "0.2.3"
+"@snowfork/snowbridge-types@link:../types":
+  version "0.0.0"
+  uid ""
 
 "@szmarczak/http-timer@^1.1.2":
   version "1.1.2"

--- a/types/README.md
+++ b/types/README.md
@@ -2,6 +2,13 @@
 
 Type definitions for the Snowbridge parachain
 
+## Development
+
+```bash
+yarn install
+yarn build
+```
+
 ## Usage
 
 Import the types in your JS or TS app:
@@ -10,6 +17,6 @@ Import the types in your JS or TS app:
 import { ApiPromise } from '@polkadot/api';
 import { bundle } from "@snowfork/snowbridge-types";
 
-const makeAPI = async (provider) =>
+const makeAPI = (provider) =>
     ApiPromise.create({ provider, typesBundle: bundle });
 ```

--- a/types/package.json
+++ b/types/package.json
@@ -22,7 +22,7 @@
   ],
   "scripts": {
     "build": "tsc",
-    "prepublish": "yarn build"
+    "prepack": "tsc"
   },
   "devDependencies": {
     "@polkadot/keyring": "^5.7.1",


### PR DESCRIPTION
A new step is now required before setting up the E2E test stack:

```bash
cd ../types  # change into the toplevel types directory
yarn install
yarn build


# continue with rest of setup...
```

This is so we can link the `@snowfork/snowbridge-types` package correctly into the dependencies for the e2e tests.