### PR TITLE
Use transactional storage

### DIFF
--- a/parachain/pallets/erc20-app/src/lib.rs
+++ b/parachain/pallets/erc20-app/src/lib.rs
@@ -21,6 +21,7 @@ use frame_support::{
 	decl_error, decl_event, decl_module, decl_storage,
 	dispatch::{DispatchError, DispatchResult},
 	traits::EnsureOrigin,
+	transactional,
 };
 use sp_runtime::traits::StaticLookup;
 use sp_std::prelude::*;
@@ -81,6 +82,7 @@ decl_module! {
 
 		/// Burn an ERC20 token balance
 		#[weight = 0]
+		#[transactional]
 		pub fn burn(origin, channel_id: ChannelId, token: H160, recipient: H160, amount: U256) -> DispatchResult {
 			let who = ensure_signed(origin)?;
 
@@ -100,6 +102,7 @@ decl_module! {
 		}
 
 		#[weight = 0]
+		#[transactional]
 		pub fn mint(origin, token: H160, sender: H160, recipient: <T::Lookup as StaticLookup>::Source, amount: U256) -> DispatchResult {
 			let who = T::CallOrigin::ensure_origin(origin)?;
 			if who != Address::get() {

--- a/parachain/pallets/eth-app/src/lib.rs
+++ b/parachain/pallets/eth-app/src/lib.rs
@@ -21,6 +21,7 @@ use frame_support::{
 	decl_error, decl_event, decl_module, decl_storage,
 	dispatch::{DispatchError, DispatchResult},
 	traits::EnsureOrigin,
+	transactional,
 };
 use sp_runtime::traits::StaticLookup;
 use sp_std::prelude::*;
@@ -82,6 +83,7 @@ decl_module! {
 		// Users should burn their holdings to release funds on the Ethereum side
 		// TODO: Calculate weights
 		#[weight = 0]
+		#[transactional]
 		pub fn burn(origin, channel_id: ChannelId, recipient: H160, amount: U256) -> DispatchResult {
 			let who = ensure_signed(origin)?;
 
@@ -100,6 +102,7 @@ decl_module! {
 		}
 
 		#[weight = 0]
+		#[transactional]
 		pub fn mint(origin, sender: H160, recipient: <T::Lookup as StaticLookup>::Source, amount: U256) -> DispatchResult {
 			let who = T::CallOrigin::ensure_origin(origin)?;
 			if who != Address::get() {


### PR DESCRIPTION
This is a followup to #271 to add the [transactional](https://substrate.dev/rustdocs/v3.0.0/frame_support/attr.transactional.html) annotation to dispatchables in the ETH and ERC20 pallets (Its already used in the DOT pallet).

Specifically this fixes a potential issue where users could burn SnowETH, SnowERC20, yet not have the message relayed across the bridge, in effect destroying their assets permanently. This would happen if the commitments pallet isn't able to accept the message for any reason (full queue, etc).


