### PR TITLE
Pin Polkadot version

### DIFF
--- a/parachain/README.md
+++ b/parachain/README.md
@@ -51,7 +51,7 @@ Build Polkadot:
 ```bash
 git clone -n https://github.com/paritytech/polkadot.git /tmp/polkadot
 cd /tmp/polkadot
-git checkout rococo-v1
+git checkout 8daf97
 cargo build --release --features=real-overseer
 ```
 


### PR DESCRIPTION
It seems we're getting all kinds of issues with different revisions of `rococo-v1` branch, so let's pin to `8daf97`, which seems to work nicely.