### PR TITLE
Fix for invalid transaction signing

### DIFF
--- a/relayer/chain/substrate/writer.go
+++ b/relayer/chain/substrate/writer.go
@@ -17,12 +17,13 @@ import (
 )
 
 type Writer struct {
-	conn     *Connection
-	messages <-chan []chain.Message
-	headers  <-chan chain.Header
-	log      *logrus.Entry
-	nonce    uint32
-	pool     *extrinsicPool
+	conn        *Connection
+	messages    <-chan []chain.Message
+	headers     <-chan chain.Header
+	log         *logrus.Entry
+	nonce       uint32
+	pool        *extrinsicPool
+	genesisHash types.Hash
 }
 
 func NewWriter(conn *Connection, messages <-chan []chain.Message, headers <-chan chain.Header, log *logrus.Entry) (*Writer, error) {
@@ -40,6 +41,12 @@ func (wr *Writer) Start(ctx context.Context, eg *errgroup.Group) error {
 		return err
 	}
 	wr.nonce = nonce
+
+	genesisHash, err := wr.conn.api.RPC.Chain.GetBlockHash(0)
+	if err != nil {
+		return err
+	}
+	wr.genesisHash = genesisHash
 
 	wr.pool = newExtrinsicPool(eg, wr.conn, wr.log)
 
@@ -121,22 +128,17 @@ func (wr *Writer) writeLoop(ctx context.Context) error {
 func (wr *Writer) write(ctx context.Context, c types.Call) error {
 	ext := types.NewExtrinsic(c)
 
-	latestBlock, err := wr.conn.api.RPC.Chain.GetBlockLatest()
+	latestHash, err := wr.conn.api.RPC.Chain.GetFinalizedHead()
+	if err != nil {
+		return err
+	}
+
+	latestBlock, err := wr.conn.api.RPC.Chain.GetBlock(latestHash)
 	if err != nil {
 		return err
 	}
 
 	era := NewMortalEra(uint64(latestBlock.Block.Header.Number))
-
-	genesisHash, err := wr.conn.api.RPC.Chain.GetBlockHash(0)
-	if err != nil {
-		return err
-	}
-
-	latestHash, err := wr.conn.api.RPC.Chain.GetBlockHashLatest()
-	if err != nil {
-		return err
-	}
 
 	rv, err := wr.conn.api.RPC.State.GetRuntimeVersionLatest()
 	if err != nil {
@@ -146,7 +148,7 @@ func (wr *Writer) write(ctx context.Context, c types.Call) error {
 	o := types.SignatureOptions{
 		BlockHash:          latestHash,
 		Era:                era,
-		GenesisHash:        genesisHash,
+		GenesisHash:        wr.genesisHash,
 		Nonce:              types.NewUCompactFromUInt(uint64(wr.nonce)),
 		SpecVersion:        rv.SpecVersion,
 		Tip:                types.NewUCompactFromUInt(0),


### PR DESCRIPTION
This should fix the issue where the relayer self-terminates upon receiving an "Invalid Transaction" error from the Substrate transaction pool.

In my investigation, I saw the following error in the parachain logs, which has this [explanation](https://github.com/paritytech/substrate/blob/9b08105b8c7106d723c4f470304ad9e2868569d9/primitives/runtime/src/transaction_validity.rs#L46):
```
Transaction pool error: Invalid transaction validity: InvalidTransaction::BadProof
```

Looking through our transaction signing logic in the relayer, I think I found the root cause: https://github.com/Snowfork/polkadot-ethereum/blob/af643f51cc3403fe170da68d92bebde40e244068/relayer/chain/substrate/writer.go#L147

The `BlockHash` field needs to refer to the block hash used to compute the transaction era. But that is not the case in our code, as we request the latest block hash again. After this signed transaction is submitted to the pool, its signature verification will fail if `BlockHash` doesn't match the hash used to generate the era.

Other changes:
* Used `GetFinalizedHead` instead of `GetBlockLatest` to ensure we're using latest head from the canonical chain.
* Cache `genesisHash` so we don't need to fetch it every time.