### PR TITLE
Limit number of messages in commitment queues

### DIFF
--- a/parachain/pallets/commitments/src/mock.rs
+++ b/parachain/pallets/commitments/src/mock.rs
@@ -52,12 +52,14 @@ impl frame_system::Config for Test {
 
 parameter_types! {
 	pub const CommitInterval: u64 = 5;
+	pub const MaxMessagesPerCommit: usize = 2;
 }
 
 impl commitments::Config for Test {
 	const INDEXING_PREFIX: &'static [u8] = b"commitment";
 	type Event = Event;
 	type Hashing = Keccak256;
+	type MaxMessagesPerCommit = MaxMessagesPerCommit;
 }
 
 // Build genesis storage according to the mock runtime.

--- a/parachain/runtime/local/src/lib.rs
+++ b/parachain/runtime/local/src/lib.rs
@@ -441,12 +441,14 @@ impl verifier_lightclient::Config for Runtime {
 
 parameter_types! {
 	pub const CommitInterval: BlockNumber = 5;
+	pub const MaxMessagesPerCommit: usize = 100;
 }
 
 impl commitments::Config for Runtime {
 	const INDEXING_PREFIX: &'static [u8] = b"commitment";
 	type Event = Event;
 	type Hashing = Keccak256;
+	type MaxMessagesPerCommit = MaxMessagesPerCommit;
 }
 
 impl assets::Config for Runtime {

--- a/parachain/runtime/local/src/lib.rs
+++ b/parachain/runtime/local/src/lib.rs
@@ -441,7 +441,7 @@ impl verifier_lightclient::Config for Runtime {
 
 parameter_types! {
 	pub const CommitInterval: BlockNumber = 5;
-	pub const MaxMessagesPerCommit: usize = 100;
+	pub const MaxMessagesPerCommit: usize = 20;
 }
 
 impl commitments::Config for Runtime {

--- a/parachain/runtime/rococo/src/lib.rs
+++ b/parachain/runtime/rococo/src/lib.rs
@@ -443,12 +443,14 @@ impl verifier_lightclient::Config for Runtime {
 
 parameter_types! {
 	pub const CommitInterval: BlockNumber = 5;
+	pub const MaxMessagesPerCommit: usize = 100;
 }
 
 impl commitments::Config for Runtime {
 	const INDEXING_PREFIX: &'static [u8] = b"commitment";
 	type Event = Event;
 	type Hashing = Keccak256;
+	type MaxMessagesPerCommit = MaxMessagesPerCommit;
 }
 
 impl assets::Config for Runtime {

--- a/parachain/runtime/rococo/src/lib.rs
+++ b/parachain/runtime/rococo/src/lib.rs
@@ -443,7 +443,7 @@ impl verifier_lightclient::Config for Runtime {
 
 parameter_types! {
 	pub const CommitInterval: BlockNumber = 5;
-	pub const MaxMessagesPerCommit: usize = 100;
+	pub const MaxMessagesPerCommit: usize = 20;
 }
 
 impl commitments::Config for Runtime {

--- a/parachain/runtime/snowbridge/src/lib.rs
+++ b/parachain/runtime/snowbridge/src/lib.rs
@@ -443,12 +443,14 @@ impl verifier_lightclient::Config for Runtime {
 
 parameter_types! {
 	pub const CommitInterval: BlockNumber = 5;
+	pub const MaxMessagesPerCommit: usize = 100;
 }
 
 impl commitments::Config for Runtime {
 	const INDEXING_PREFIX: &'static [u8] = b"commitment";
 	type Event = Event;
 	type Hashing = Keccak256;
+	type MaxMessagesPerCommit = MaxMessagesPerCommit;
 }
 
 impl assets::Config for Runtime {

--- a/parachain/runtime/snowbridge/src/lib.rs
+++ b/parachain/runtime/snowbridge/src/lib.rs
@@ -443,7 +443,7 @@ impl verifier_lightclient::Config for Runtime {
 
 parameter_types! {
 	pub const CommitInterval: BlockNumber = 5;
-	pub const MaxMessagesPerCommit: usize = 100;
+	pub const MaxMessagesPerCommit: usize = 20;
 }
 
 impl commitments::Config for Runtime {


### PR DESCRIPTION
This PR sets an upper bound on the number of messages that can be queued / committed per channel in the commitments pallet. This resolves https://github.com/Snowfork/polkadot-ethereum/issues/226