### PR TITLE
Benchmark parachain's DB, extrinsic and block overheads

### DIFF
--- a/parachain/Cargo.lock
+++ b/parachain/Cargo.lock
@@ -440,6 +440,7 @@ dependencies = [
  "artemis-erc20-app",
  "artemis-eth-app",
  "artemis-incentivized-channel",
+ "artemis-runtime-common",
  "artemis-transfer",
  "artemis-xcm-support",
  "cumulus-pallet-parachain-system",
@@ -478,6 +479,15 @@ dependencies = [
  "xcm",
  "xcm-builder",
  "xcm-executor",
+]
+
+[[package]]
+name = "artemis-runtime-common"
+version = "0.1.0"
+dependencies = [
+ "frame-support",
+ "frame-system",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -4249,6 +4259,7 @@ dependencies = [
  "artemis-erc20-app",
  "artemis-eth-app",
  "artemis-incentivized-channel",
+ "artemis-runtime-common",
  "artemis-transfer",
  "artemis-xcm-support",
  "cumulus-pallet-parachain-system",
@@ -9015,6 +9026,7 @@ dependencies = [
  "artemis-erc20-app",
  "artemis-eth-app",
  "artemis-incentivized-channel",
+ "artemis-runtime-common",
  "artemis-transfer",
  "artemis-xcm-support",
  "cumulus-pallet-parachain-system",

--- a/parachain/runtime/common/Cargo.toml
+++ b/parachain/runtime/common/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "artemis-runtime-common"
+description = "Artemis Runtime Common"
+version = "0.1.0"
+authors = ["Snowfork <contact@snowfork.com>"]
+edition = "2018"
+repository = "https://github.com/Snowfork/polkadot-ethereum"
+
+[dependencies]
+frame-support = { git = "https://github.com/paritytech/substrate.git", branch = "rococo-v1", default-features = false }
+frame-system = { git = "https://github.com/paritytech/substrate.git", branch = "rococo-v1", default-features = false }
+sp-runtime = { git = "https://github.com/paritytech/substrate.git", branch = "rococo-v1", default-features = false }
+
+[features]
+default = ["std"]
+std = [
+    "frame-support/std",
+    "frame-system/std",
+    "sp-runtime/std",
+]

--- a/parachain/runtime/common/src/lib.rs
+++ b/parachain/runtime/common/src/lib.rs
@@ -1,0 +1,33 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
+use frame_support::weights::{DispatchClass, Weight};
+use frame_system::limits::BlockWeights;
+use sp_runtime::Perbill;
+
+// This function replicates BlockWeights::with_sensible_defaults but uses custom
+// base block and extrinsic weights.
+// https://github.com/paritytech/substrate/blob/4898eb350d636d439827cb43f0f26e72e66492fa/frame/system/src/limits.rs#L312
+pub fn build_block_weights(
+    base_block_weight: Weight,
+    base_extrinsic_weight: Weight,
+    expected_block_weight: Weight,
+    normal_ratio: Perbill,
+) -> BlockWeights {
+    let normal_weight = normal_ratio * expected_block_weight;
+
+    BlockWeights::builder()
+        .base_block(base_block_weight)
+        .for_class(DispatchClass::all(), |weights| {
+            weights.base_extrinsic = base_extrinsic_weight.into();
+        })
+        .for_class(DispatchClass::Normal, |weights| {
+            weights.max_total = normal_weight.into();
+        })
+        .for_class(DispatchClass::Operational, |weights| {
+            weights.max_total = expected_block_weight.into();
+            weights.reserved = (expected_block_weight - normal_weight).into();
+        })
+        .avg_block_initialization(Perbill::from_percent(10))
+        .build()
+        .expect("Weights must be valid")
+}

--- a/parachain/runtime/local/Cargo.toml
+++ b/parachain/runtime/local/Cargo.toml
@@ -56,6 +56,7 @@ dot-app = { path = "../../pallets/dot-app", package = "artemis-dot-app", default
 eth-app = { path = "../../pallets/eth-app", package = "artemis-eth-app", default-features = false }
 erc20-app = { path = "../../pallets/erc20-app", package = "artemis-erc20-app", default-features = false }
 commitments = { path = "../../pallets/commitments", package = "artemis-commitments", default-features = false }
+runtime-common = { path = "../common", package = "artemis-runtime-common", default-features = false }
 
 # Used for runtime benchmarking
 frame-benchmarking = { git = "https://github.com/paritytech/substrate.git", branch = "rococo-v1", default-features = false, optional = true }
@@ -108,7 +109,8 @@ std = [
     "erc20-app/std",
     "commitments/std",
     "artemis-transfer/std",
-    "artemis-xcm-support/std"
+    "artemis-xcm-support/std",
+    "runtime-common/std",
 ]
 runtime-benchmarks = [
     "sp-runtime/runtime-benchmarks",

--- a/parachain/runtime/local/src/lib.rs
+++ b/parachain/runtime/local/src/lib.rs
@@ -142,8 +142,12 @@ parameter_types! {
 	pub const Version: RuntimeVersion = VERSION;
 	pub const BlockHashCount: BlockNumber = 2400;
 	/// We allow for 2 seconds of compute with a 6 second average block time.
-	pub BlockWeights: frame_system::limits::BlockWeights = frame_system::limits::BlockWeights
-		::with_sensible_defaults(2 * WEIGHT_PER_SECOND, NORMAL_DISPATCH_RATIO);
+	pub BlockWeights: frame_system::limits::BlockWeights = runtime_common::build_block_weights(
+		BlockExecutionWeight::get(),
+		ExtrinsicBaseWeight::get(),
+		2 * WEIGHT_PER_SECOND,
+		NORMAL_DISPATCH_RATIO,
+	);
 	pub BlockLength: frame_system::limits::BlockLength = frame_system::limits::BlockLength
 		::max_with_normal_ratio(5 * 1024 * 1024, NORMAL_DISPATCH_RATIO);
 	pub const SS58Prefix: u8 = 42;

--- a/parachain/runtime/rococo/Cargo.toml
+++ b/parachain/runtime/rococo/Cargo.toml
@@ -56,6 +56,7 @@ dot-app = { path = "../../pallets/dot-app", package = "artemis-dot-app", default
 eth-app = { path = "../../pallets/eth-app", package = "artemis-eth-app", default-features = false }
 erc20-app = { path = "../../pallets/erc20-app", package = "artemis-erc20-app", default-features = false }
 commitments = { path = "../../pallets/commitments", package = "artemis-commitments", default-features = false }
+runtime-common = { path = "../common", package = "artemis-runtime-common", default-features = false }
 
 # Used for runtime benchmarking
 frame-benchmarking = { git = "https://github.com/paritytech/substrate.git", branch = "rococo-v1", default-features = false, optional = true }
@@ -108,7 +109,8 @@ std = [
     "erc20-app/std",
     "commitments/std",
     "artemis-transfer/std",
-    "artemis-xcm-support/std"
+    "artemis-xcm-support/std",
+    "runtime-common/std",
 ]
 runtime-benchmarks = [
     "sp-runtime/runtime-benchmarks",

--- a/parachain/runtime/rococo/src/lib.rs
+++ b/parachain/runtime/rococo/src/lib.rs
@@ -144,8 +144,12 @@ parameter_types! {
 	pub const Version: RuntimeVersion = VERSION;
 	pub const BlockHashCount: BlockNumber = 2400;
 	/// We allow for 2 seconds of compute with a 6 second average block time.
-	pub BlockWeights: frame_system::limits::BlockWeights = frame_system::limits::BlockWeights
-		::with_sensible_defaults(2 * WEIGHT_PER_SECOND, NORMAL_DISPATCH_RATIO);
+	pub BlockWeights: frame_system::limits::BlockWeights = runtime_common::build_block_weights(
+		BlockExecutionWeight::get(),
+		ExtrinsicBaseWeight::get(),
+		2 * WEIGHT_PER_SECOND,
+		NORMAL_DISPATCH_RATIO,
+	);
 	pub BlockLength: frame_system::limits::BlockLength = frame_system::limits::BlockLength
 		::max_with_normal_ratio(5 * 1024 * 1024, NORMAL_DISPATCH_RATIO);
 	pub const SS58Prefix: u8 = 42;

--- a/parachain/runtime/rococo/src/lib.rs
+++ b/parachain/runtime/rococo/src/lib.rs
@@ -36,7 +36,7 @@ pub use frame_support::{
 	traits::{KeyOwnerProofSystem, Randomness, Filter},
 	weights::{
 		Weight, IdentityFee,
-		constants::{BlockExecutionWeight, ExtrinsicBaseWeight, RocksDbWeight, WEIGHT_PER_SECOND},
+		constants::WEIGHT_PER_SECOND,
 	},
 };
 use frame_system::EnsureRoot;
@@ -145,8 +145,8 @@ parameter_types! {
 	pub const BlockHashCount: BlockNumber = 2400;
 	/// We allow for 2 seconds of compute with a 6 second average block time.
 	pub BlockWeights: frame_system::limits::BlockWeights = runtime_common::build_block_weights(
-		BlockExecutionWeight::get(),
-		ExtrinsicBaseWeight::get(),
+		weights::constants::BlockExecutionWeight::get(),
+		weights::constants::ExtrinsicBaseWeight::get(),
 		2 * WEIGHT_PER_SECOND,
 		NORMAL_DISPATCH_RATIO,
 	);
@@ -187,7 +187,7 @@ impl frame_system::Config for Runtime {
 	/// Maximum number of block number to block hash mappings to keep (oldest pruned first).
 	type BlockHashCount = BlockHashCount;
 	/// The weight of database operations that the runtime can invoke.
-	type DbWeight = RocksDbWeight;
+	type DbWeight = weights::constants::RocksDbWeight;
 	/// Version of the runtime.
 	type Version = Version;
 	/// Converts a module to the index of the module in `construct_runtime!`.

--- a/parachain/runtime/rococo/src/weights/constants.rs
+++ b/parachain/runtime/rococo/src/weights/constants.rs
@@ -8,10 +8,10 @@ parameter_types! {
     /// Weight of importing a block with 0 txs
     pub const BlockExecutionWeight: Weight = 9 * WEIGHT_PER_MILLIS;
     /// Weight of executing 10,000 System remarks (no-op) txs
-    pub const ExtrinsicBaseWeight: Weight = 312 * WEIGHT_PER_MICROS;
+    pub const ExtrinsicBaseWeight: Weight = 297 * WEIGHT_PER_MICROS;
     /// Weight of reads and writes to RocksDB, the default DB used by Substrate
     pub const RocksDbWeight: RuntimeDbWeight = RuntimeDbWeight {
-        read: 28 * WEIGHT_PER_MICROS,
-        write: 110 * WEIGHT_PER_MICROS,
+        read: 30 * WEIGHT_PER_MICROS,
+        write: 112 * WEIGHT_PER_MICROS,
     };
 }

--- a/parachain/runtime/rococo/src/weights/mod.rs
+++ b/parachain/runtime/rococo/src/weights/mod.rs
@@ -1,3 +1,5 @@
+pub mod constants;
+
 pub mod assets_weights;
 pub mod basic_channel_inbound_weights;
 pub mod dot_app_weights;

--- a/parachain/runtime/snowbridge/Cargo.toml
+++ b/parachain/runtime/snowbridge/Cargo.toml
@@ -56,6 +56,7 @@ dot-app = { path = "../../pallets/dot-app", package = "artemis-dot-app", default
 eth-app = { path = "../../pallets/eth-app", package = "artemis-eth-app", default-features = false }
 erc20-app = { path = "../../pallets/erc20-app", package = "artemis-erc20-app", default-features = false }
 commitments = { path = "../../pallets/commitments", package = "artemis-commitments", default-features = false }
+runtime-common = { path = "../common", package = "artemis-runtime-common", default-features = false }
 
 # Used for runtime benchmarking
 frame-benchmarking = { git = "https://github.com/paritytech/substrate.git", branch = "rococo-v1", default-features = false, optional = true }
@@ -108,7 +109,8 @@ std = [
     "erc20-app/std",
     "commitments/std",
     "artemis-transfer/std",
-    "artemis-xcm-support/std"
+    "artemis-xcm-support/std",
+    "runtime-common/std",
 ]
 runtime-benchmarks = [
     "sp-runtime/runtime-benchmarks",

--- a/parachain/runtime/snowbridge/src/lib.rs
+++ b/parachain/runtime/snowbridge/src/lib.rs
@@ -144,8 +144,12 @@ parameter_types! {
 	pub const Version: RuntimeVersion = VERSION;
 	pub const BlockHashCount: BlockNumber = 2400;
 	/// We allow for 2 seconds of compute with a 6 second average block time.
-	pub BlockWeights: frame_system::limits::BlockWeights = frame_system::limits::BlockWeights
-		::with_sensible_defaults(2 * WEIGHT_PER_SECOND, NORMAL_DISPATCH_RATIO);
+	pub BlockWeights: frame_system::limits::BlockWeights = runtime_common::build_block_weights(
+		BlockExecutionWeight::get(),
+		ExtrinsicBaseWeight::get(),
+		2 * WEIGHT_PER_SECOND,
+		NORMAL_DISPATCH_RATIO,
+	);
 	pub BlockLength: frame_system::limits::BlockLength = frame_system::limits::BlockLength
 		::max_with_normal_ratio(5 * 1024 * 1024, NORMAL_DISPATCH_RATIO);
 	pub const SS58Prefix: u8 = 42;

--- a/parachain/runtime/snowbridge/src/lib.rs
+++ b/parachain/runtime/snowbridge/src/lib.rs
@@ -36,7 +36,7 @@ pub use frame_support::{
 	traits::{KeyOwnerProofSystem, Randomness, Filter},
 	weights::{
 		Weight, IdentityFee,
-		constants::{BlockExecutionWeight, ExtrinsicBaseWeight, RocksDbWeight, WEIGHT_PER_SECOND},
+		constants::WEIGHT_PER_SECOND,
 	},
 };
 use frame_system::EnsureRoot;
@@ -145,8 +145,8 @@ parameter_types! {
 	pub const BlockHashCount: BlockNumber = 2400;
 	/// We allow for 2 seconds of compute with a 6 second average block time.
 	pub BlockWeights: frame_system::limits::BlockWeights = runtime_common::build_block_weights(
-		BlockExecutionWeight::get(),
-		ExtrinsicBaseWeight::get(),
+		weights::constants::BlockExecutionWeight::get(),
+		weights::constants::ExtrinsicBaseWeight::get(),
 		2 * WEIGHT_PER_SECOND,
 		NORMAL_DISPATCH_RATIO,
 	);
@@ -187,7 +187,7 @@ impl frame_system::Config for Runtime {
 	/// Maximum number of block number to block hash mappings to keep (oldest pruned first).
 	type BlockHashCount = BlockHashCount;
 	/// The weight of database operations that the runtime can invoke.
-	type DbWeight = RocksDbWeight;
+	type DbWeight = weights::constants::RocksDbWeight;
 	/// Version of the runtime.
 	type Version = Version;
 	/// Converts a module to the index of the module in `construct_runtime!`.

--- a/parachain/runtime/snowbridge/src/weights/constants.rs
+++ b/parachain/runtime/snowbridge/src/weights/constants.rs
@@ -1,0 +1,14 @@
+use frame_support::{
+    weights::{RuntimeDbWeight, Weight},
+    weights::constants::{WEIGHT_PER_MILLIS, WEIGHT_PER_MICROS},
+}
+
+/// Weight of importing a block with 0 txs
+pub const BLOCK_EXECUTION_WEIGHT: Weight = {{ block_execution_weight_in_millis }} * WEIGHT_PER_MILLIS;
+/// Weight of executing 10,000 System remarks (no-op) txs
+pub const EXTRINSIC_BASE_WEIGHT: Weight = {{ extrinsic_base_weight_in_micros }} * WEIGHT_PER_MICROS;
+/// Weight of reads and writes to RocksDB, the default DB used by Sgitubstrate
+pub const ROCKS_DB_WEIGHT: RuntimeDbWeight = RuntimeDbWeight {
+    read: {{ rocksdb_read_weight_in_micros }} * WEIGHT_PER_MICROS,
+    write: {{ rocksdb_write_weight_in_micros }} * WEIGHT_PER_MICROS,
+};

--- a/parachain/runtime/snowbridge/src/weights/mod.rs
+++ b/parachain/runtime/snowbridge/src/weights/mod.rs
@@ -1,3 +1,5 @@
+pub mod constants;
+
 pub mod assets_weights;
 pub mod basic_channel_inbound_weights;
 pub mod dot_app_weights;

--- a/parachain/scripts/benchmark.sh
+++ b/parachain/scripts/benchmark.sh
@@ -39,6 +39,9 @@ benchmark_pallets()
 
     echo "Generating weights module for $RUNTIME_DIR with pallets $PALLETS"
 
+    echo "pub mod constants;" >> $TMP_DIR/mod.rs
+    echo "" >> $TMP_DIR/mod.rs
+
     for pallet in $PALLETS
     do
         MODULE_NAME="$(tr -s [:] _ <<< $pallet)_weights"
@@ -61,7 +64,7 @@ benchmark_pallets()
 
 benchmark_node()
 {
-    echo "Benchmarking node. This will take a few minutes..."
+    echo "Benchmarking node. This can take 1 to 2 hours"
 
     cargo install node-bench --version 0.8.0
     yarn global add handlebars-cmd@0.1.4
@@ -69,9 +72,9 @@ benchmark_node()
     echo "[
         $(node-bench -j ::trie::read::large),
         $(node-bench -j ::trie::write::large),
-        $(node-bench -j ::node::import::wasm::sr25519::noop::rocksdb::custom --transactions 10000),
+        $(node-bench -j ::node::import::wasm::sr25519::noop::rocksdb::custom --transactions 5000),
         $(node-bench -j ::node::import::wasm::sr25519::noop::rocksdb::empty)
-    ]" | node scripts/helpers/parseNodeBenchOutput.js > $TMP_DIR/node_bench_results.json
+    ]" | node scripts/helpers/parseNodeBenchOutput.js 5000 > $TMP_DIR/node_bench_results.json
 
     echo "Generating weight constants for node"
 

--- a/parachain/scripts/benchmark.sh
+++ b/parachain/scripts/benchmark.sh
@@ -16,42 +16,71 @@ else
     exit 1
 fi
 
-echo "Building runtime with features $RUNTIME_FEATURE,runtime-benchmarks"
+benchmark_pallets()
+{
+    echo "Building runtime with features $RUNTIME_FEATURE,runtime-benchmarks"
 
-FORCE_WASM_BUILD=$(date +%s) cargo build --release \
-    --no-default-features \
-    --features runtime-benchmarks,$RUNTIME_FEATURE
+    FORCE_WASM_BUILD=$(date +%s) cargo build --release \
+        --no-default-features \
+        --features runtime-benchmarks,$RUNTIME_FEATURE
 
-echo "Generating benchmark spec at $TMP_DIR/spec.json"
+    echo "Generating benchmark spec at $TMP_DIR/spec.json"
 
-target/release/artemis build-spec > $TMP_DIR/spec.json
-# Initialize dot-app account with enough DOT for benchmarks
-DOT_MODULE_ENDOWMENT="[
-    \"5EYCAe5jHEQsVPTRQqy6NCeG71Hz1EVXikZxTkr67fM8j2Rd\",
-    1152921504606846976
-]"
-node ../test/scripts/helpers/overrideParachainSpec.js $TMP_DIR/spec.json \
-    genesis.runtime.palletBalances.balances.0 "$DOT_MODULE_ENDOWMENT"
+    target/release/artemis build-spec > $TMP_DIR/spec.json
+    # Initialize dot-app account with enough DOT for benchmarks
+    DOT_MODULE_ENDOWMENT="[
+        \"5EYCAe5jHEQsVPTRQqy6NCeG71Hz1EVXikZxTkr67fM8j2Rd\",
+        1152921504606846976
+    ]"
+    node ../test/scripts/helpers/overrideParachainSpec.js $TMP_DIR/spec.json \
+        genesis.runtime.palletBalances.balances.0 "$DOT_MODULE_ENDOWMENT"
 
-PALLETS="assets basic_channel::inbound dot_app erc20_app eth_app frame_system incentivized_channel::inbound pallet_balances pallet_timestamp verifier_lightclient"
+    PALLETS="assets basic_channel::inbound dot_app erc20_app eth_app frame_system incentivized_channel::inbound pallet_balances pallet_timestamp verifier_lightclient"
 
-echo "Generating weights module for $RUNTIME_DIR with pallets $PALLETS"
+    echo "Generating weights module for $RUNTIME_DIR with pallets $PALLETS"
 
-for pallet in $PALLETS
-do
-    MODULE_NAME="$(tr -s [:] _ <<< $pallet)_weights"
-    target/release/artemis benchmark \
-        --chain $TMP_DIR/spec.json \
-        --execution wasm \
-        --wasm-execution compiled \
-        --pallet "${pallet}" \
-        --extrinsic "*" \
-        --repeat 20 \
-        --steps 50 \
-        --output $RUNTIME_DIR/src/weights/$MODULE_NAME.rs
-    echo "pub mod $MODULE_NAME;" >> $TMP_DIR/mod.rs
-done
+    for pallet in $PALLETS
+    do
+        MODULE_NAME="$(tr -s [:] _ <<< $pallet)_weights"
+        target/release/artemis benchmark \
+            --chain $TMP_DIR/spec.json \
+            --execution wasm \
+            --wasm-execution compiled \
+            --pallet "${pallet}" \
+            --extrinsic "*" \
+            --repeat 20 \
+            --steps 50 \
+            --output $RUNTIME_DIR/src/weights/$MODULE_NAME.rs
+        echo "pub mod $MODULE_NAME;" >> $TMP_DIR/mod.rs
+    done
 
-mv $TMP_DIR/mod.rs $RUNTIME_DIR/src/weights/mod.rs
+    mv $TMP_DIR/mod.rs $RUNTIME_DIR/src/weights/mod.rs
 
-echo "Done!"
+    echo "Done generating extrinsic weights"
+}
+
+benchmark_node()
+{
+    echo "Benchmarking node. This will take a few minutes..."
+
+    cargo install node-bench --version 0.8.0
+    yarn global add handlebars-cmd@0.1.4
+
+    echo "[
+        $(node-bench -j ::trie::read::large),
+        $(node-bench -j ::trie::write::large),
+        $(node-bench -j ::node::import::wasm::sr25519::noop::rocksdb::custom --transactions 10000),
+        $(node-bench -j ::node::import::wasm::sr25519::noop::rocksdb::empty)
+    ]" | node scripts/helpers/parseNodeBenchOutput.js > $TMP_DIR/node_bench_results.json
+
+    echo "Generating weight constants for node"
+
+    handlebars $TMP_DIR/node_bench_results.json \
+        < scripts/helpers/weight-constants-template.hbs \
+        > $RUNTIME_DIR/src/weights/constants.rs
+
+    echo "Done generating node weights"
+}
+
+benchmark_pallets
+benchmark_node

--- a/parachain/scripts/helpers/parseNodeBenchOutput.js
+++ b/parachain/scripts/helpers/parseNodeBenchOutput.js
@@ -1,0 +1,45 @@
+const readline = require('readline');
+
+const PATTERNS = {
+    'block_execution_weight': /^Block import \(Noop\/empty/,
+    'extrinsic_base_weight': /^Block import \(Noop\/custom/,
+    'rocksdb_read_weight': /^Trie read benchmark/,
+    'rocksdb_write_weight': /^Trie write benchmark/,
+};
+
+function extractWeights(benchOutput) {
+    return benchOutput
+        .flat()
+        .filter(output => output.name.includes("RocksDb"))
+        .map(output => {
+            const [key, _] = Object.entries(PATTERNS).find(([_, p]) => p.test(output.name));
+            return [key, output.average];
+        })
+        .reduce(
+            (obj, [key, weight]) => key === undefined ? obj : { ...obj, [key]: weight },
+            {},
+        );
+}
+
+function run() {
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+    terminal: false
+  });
+
+  let buffer = "";
+  rl.on('line', function(line){
+    buffer += line;
+  });
+
+  rl.on('close', function() {
+    console.log(JSON.stringify(
+      extractWeights(JSON.parse(buffer)),
+      null, // replacer
+      4, // spaces
+    ));
+  });
+}
+
+run();

--- a/parachain/scripts/helpers/weight-constants-template.hbs
+++ b/parachain/scripts/helpers/weight-constants-template.hbs
@@ -1,14 +1,17 @@
 use frame_support::{
+    parameter_types,
     weights::{RuntimeDbWeight, Weight},
-    weights::constants::WEIGHT_PER_NANOS,
-}
-
-/// Weight of importing a block with 0 txs
-pub const BLOCK_EXECUTION_WEIGHT: Weight = {{block_execution_weight}} * WEIGHT_PER_NANOS;
-/// Weight of executing 10,000 System remarks (no-op) txs
-pub const EXTRINSIC_BASE_WEIGHT: Weight = {{extrinsic_base_weight}} * WEIGHT_PER_NANOS;
-/// Weight of reads and writes to RocksDB, the default DB used by Substrate
-pub const ROCKS_DB_WEIGHT: RuntimeDbWeight = RuntimeDbWeight {
-    read: {{rocksdb_read_weight}} * WEIGHT_PER_NANOS,
-    write: {{rocksdb_write_weight}} * WEIGHT_PER_NANOS,
+    weights::constants::{WEIGHT_PER_MICROS, WEIGHT_PER_MILLIS},
 };
+
+parameter_types! {
+    /// Weight of importing a block with 0 txs
+    pub const BlockExecutionWeight: Weight = {{block_execution_weight_in_millis}} * WEIGHT_PER_MILLIS;
+    /// Weight of executing 10,000 System remarks (no-op) txs
+    pub const ExtrinsicBaseWeight: Weight = {{extrinsic_base_weight_in_micros}} * WEIGHT_PER_MICROS;
+    /// Weight of reads and writes to RocksDB, the default DB used by Substrate
+    pub const RocksDbWeight: RuntimeDbWeight = RuntimeDbWeight {
+        read: {{rocksdb_read_weight_in_micros}} * WEIGHT_PER_MICROS,
+        write: {{rocksdb_write_weight_in_micros}} * WEIGHT_PER_MICROS,
+    };
+}

--- a/parachain/scripts/helpers/weight-constants-template.hbs
+++ b/parachain/scripts/helpers/weight-constants-template.hbs
@@ -1,0 +1,14 @@
+use frame_support::{
+    weights::{RuntimeDbWeight, Weight},
+    weights::constants::WEIGHT_PER_NANOS,
+}
+
+/// Weight of importing a block with 0 txs
+pub const BLOCK_EXECUTION_WEIGHT: Weight = {{block_execution_weight}} * WEIGHT_PER_NANOS;
+/// Weight of executing 10,000 System remarks (no-op) txs
+pub const EXTRINSIC_BASE_WEIGHT: Weight = {{extrinsic_base_weight}} * WEIGHT_PER_NANOS;
+/// Weight of reads and writes to RocksDB, the default DB used by Substrate
+pub const ROCKS_DB_WEIGHT: RuntimeDbWeight = RuntimeDbWeight {
+    read: {{rocksdb_read_weight}} * WEIGHT_PER_NANOS,
+    write: {{rocksdb_write_weight}} * WEIGHT_PER_NANOS,
+};


### PR DESCRIPTION
This PR adds the benchmarking logic and weights for the remaining configurable weights in our runtime:
* base block weight & base extrinsic weight (configured via `BlockWeights`)
* DB read & write weights (configured via `DbWeight`)

These weights are computed using the `node-bench` Substrate crate and inserted into <runtime>/src/weights/constants.rs using a Handlebars template.

Note that I added the `artemis-runtime-common` crate. I'm hoping we can use that crate to consolidate more of the duplicated runtime logic.