### PR TITLE
Fix regression in test suite

### DIFF
--- a/test/src/ethclient/index.js
+++ b/test/src/ethclient/index.js
@@ -10,8 +10,6 @@ const WrappedToken = require('../../../ethereum/build/contracts/WrappedToken.jso
 
 
 
-const INCENTIVIZED_CHANNEL_ID = 1;
-
 /**
  * The Ethereum client for Bridge interaction
  */
@@ -75,7 +73,7 @@ class EthClient {
   async lockETH(from, amount, polkadotRecipient) {
     const recipientBytes = Buffer.from(polkadotRecipient.replace(/^0x/, ""), 'hex');
 
-    let receipt = await this.appETH.methods.lock(recipientBytes, INCENTIVIZED_CHANNEL_ID).send({
+    let receipt = await this.appETH.methods.lock(recipientBytes, 0).send({
       from: from,
       gas: 500000,
       value: this.web3.utils.toBN(amount)
@@ -98,7 +96,7 @@ class EthClient {
   async lockERC20(from, amount, polkadotRecipient) {
     const recipientBytes = Buffer.from(polkadotRecipient.replace(/^0x/, ""), 'hex');
 
-    return await this.appERC20.methods.lock(this.TestTokenAddress, recipientBytes, this.web3.utils.toBN(amount), INCENTIVIZED_CHANNEL_ID)
+    return await this.appERC20.methods.lock(this.TestTokenAddress, recipientBytes, this.web3.utils.toBN(amount), 0)
       .send({
         from,
         gas: 500000,

--- a/test/test/test.js
+++ b/test/test/test.js
@@ -15,7 +15,7 @@ const { expect } = require("chai")
 const networkID = '344';
 const TestTokenAddress = TestToken.networks[networkID].address;
 
-describe('Incentivized Bridge', function () {
+describe('Bridge', function () {
 
   let ethClient;
   let subClient;
@@ -119,7 +119,7 @@ describe('Incentivized Bridge', function () {
 
       const { gasCost } = await ethClient.lockETH(account, amount, polkadotRecipient);
 
-      await sleep(40000);
+      await sleep(50000);
 
       const afterEthBalance = await ethClient.getEthBalance(account);
       const afterSubBalance = await subClient.queryAssetBalance(polkadotRecipientSS58, this.ethAssetId);
@@ -167,7 +167,7 @@ describe('Incentivized Bridge', function () {
       await ethClient.approveERC20(account, amount);
       await ethClient.lockERC20(account, amount, polkadotRecipient);
 
-      await sleep(40000);
+      await sleep(50000);
 
       let afterEthBalance = await ethClient.getErc20Balance(account);
       let afterSubBalance = await subClient.queryAssetBalance(polkadotRecipientSS58, this.erc20AssetId);


### PR DESCRIPTION
Yesterday's big merge of #343 introduced some unnecessary/obsolete changes to our tests that caused them to fail. Reverting them.

E2E tests now pass.