### PR TITLE
Relayer reliability improvements

### DIFF
--- a/ethereum/contracts/test/TestToken.sol
+++ b/ethereum/contracts/test/TestToken.sol
@@ -5,10 +5,11 @@ import "../../node_modules/@openzeppelin/contracts/token/ERC20/ERC20.sol";
 
 contract TestToken is ERC20 {
     constructor(
-        uint256 initialSupply,
         string memory _name,
         string memory _symbol
-    ) ERC20(_name, _symbol) {
-        _mint(msg.sender, initialSupply);
+    ) ERC20(_name, _symbol) { }
+
+    function mint(uint256 _amount) public {
+        _mint(msg.sender, _amount);
     }
 }

--- a/ethereum/migrations/2_next.js
+++ b/ethereum/migrations/2_next.js
@@ -86,7 +86,7 @@ module.exports = function (deployer, network, accounts) {
       },
     );
 
-    await deployer.deploy(TestToken, 100000000, "Test Token", "TEST");
+    const token = await deployer.deploy(TestToken, "Test Token", "TEST");
 
     // Deploy ERC1820 Registry for our E2E stack.
     if (network === 'e2e_test') {
@@ -125,6 +125,13 @@ module.exports = function (deployer, network, accounts) {
         { from: administrator }
       );
     }
+
+    await token.mint("10000", {
+      from: accounts[0],
+    });
+    await token.mint("10000", {
+      from: accounts[1],
+    });
 
     // Link MerkleProof library to ValidatorRegistry
     await deployer.deploy(MerkleProof);

--- a/relayer/chain/parachain/listener.go
+++ b/relayer/chain/parachain/listener.go
@@ -5,6 +5,7 @@ package parachain
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -33,120 +34,27 @@ func NewListener(config *Config, conn *Connection, messages chan<- []chain.Messa
 }
 
 func (li *Listener) Start(ctx context.Context, eg *errgroup.Group) error {
-	eg.Go(func() error {
-		return li.pollBlocks(ctx)
-	})
 
-	return nil
-}
-
-func (li *Listener) onDone(ctx context.Context) error {
-	li.log.Info("Shutting down listener...")
-	close(li.messages)
-	return ctx.Err()
-}
-
-func (li *Listener) pollBlocks(ctx context.Context) error {
-	if li.messages == nil {
-		li.log.Info("Not polling events since channel is nil")
+	blockNumber, err := li.fetchStartBlock()
+	if err != nil {
 		return nil
 	}
 
-	// Get current block
-	block, err := li.conn.api.RPC.Chain.GetHeaderLatest()
-	if err != nil {
+	headers := make(chan types.Header)
+
+	eg.Go(func() error {
+		err = li.produceFinalizedHeaders(ctx, blockNumber, headers)
+		close(headers)
 		return err
-	}
-	currentBlock := uint32(block.Number)
+	})
 
-	retryInterval := time.Duration(10) * time.Second
-	for {
-		select {
-		case <-ctx.Done():
-			return li.onDone(ctx)
-		default:
+	eg.Go(func() error {
+		err := li.consumeFinalizedHeaders(ctx, headers)
+		close(li.messages)
+		return err
+	})
 
-			li.log.WithField("block", currentBlock).Debug("Processing block")
-
-			// Get block hash
-			finalizedHash, err := li.conn.api.RPC.Chain.GetFinalizedHead()
-			if err != nil {
-				li.log.WithError(err).Error("Failed to fetch finalized head")
-				sleep(ctx, retryInterval)
-				continue
-			}
-
-			// Get block header
-			finalizedHeader, err := li.conn.api.RPC.Chain.GetHeader(finalizedHash)
-			if err != nil {
-				li.log.WithError(err).Error("Failed to fetch header for finalized head")
-				sleep(ctx, retryInterval)
-				continue
-			}
-
-			// Sleep if the block we want comes after the most recently finalized block
-			if currentBlock > uint32(finalizedHeader.Number) {
-				li.log.WithFields(logrus.Fields{
-					"block":  currentBlock,
-					"latest": finalizedHeader.Number,
-				}).Trace("Block not yet finalized")
-				sleep(ctx, retryInterval)
-				continue
-			}
-
-			digestItem, err := getAuxiliaryDigestItem(finalizedHeader.Digest)
-			if err != nil {
-				return err
-			}
-
-			if digestItem != nil && digestItem.IsCommitment {
-				li.log.WithFields(logrus.Fields{
-					"block":          finalizedHeader.Number,
-					"channelID":      digestItem.AsCommitment.ChannelID,
-					"commitmentHash": digestItem.AsCommitment.Hash.Hex(),
-				}).Debug("Found commitment hash in header digest")
-
-				storageKey, err := MakeStorageKey(digestItem.AsCommitment.ChannelID, digestItem.AsCommitment.Hash)
-				if err != nil {
-					return err
-				}
-
-				data, err := li.conn.api.RPC.Offchain.LocalStorageGet(rpcOffchain.Persistent, storageKey)
-				if err != nil {
-					li.log.WithError(err).Error("Failed to read commitment from offchain storage")
-					sleep(ctx, retryInterval)
-					continue
-				}
-
-				if data != nil {
-					li.log.WithFields(logrus.Fields{
-						"block":               finalizedHeader.Number,
-						"commitmentSizeBytes": len(*data),
-					}).Debug("Retrieved commitment from offchain storage")
-				} else {
-					li.log.WithError(err).Error("Commitment not found in offchain storage")
-					continue
-				}
-
-				var messages []chainTypes.CommitmentMessage
-
-				err = types.DecodeFromBytes(*data, &messages)
-				if err != nil {
-					li.log.WithError(err).Error("Faild to decode commitment messages")
-				}
-
-				message := chain.SubstrateOutboundMessage{
-					ChannelID:      digestItem.AsCommitment.ChannelID,
-					CommitmentHash: digestItem.AsCommitment.Hash,
-					Commitment:     messages,
-				}
-
-				li.messages <- []chain.Message{message}
-			}
-
-			currentBlock++
-		}
-	}
+	return nil
 }
 
 func sleep(ctx context.Context, delay time.Duration) {
@@ -154,6 +62,163 @@ func sleep(ctx context.Context, delay time.Duration) {
 	case <-ctx.Done():
 	case <-time.After(delay):
 	}
+}
+
+// Fetch the starting block
+func (li *Listener) fetchStartBlock() (uint64, error) {
+	hash, err := li.conn.api.RPC.Chain.GetFinalizedHead()
+	if err != nil {
+		li.log.WithError(err).Error("Failed to fetch hash for starting block")
+		return 0, err
+	}
+
+	header, err := li.conn.api.RPC.Chain.GetHeader(hash)
+	if err != nil {
+		li.log.WithError(err).Error("Failed to fetch header for starting block")
+		return 0, err
+	}
+
+	return uint64(header.Number), nil
+}
+
+var ErrBlockNotReady = errors.New("required result to be 32 bytes, but got 0")
+
+func (li *Listener) produceFinalizedHeaders(ctx context.Context, startBlock uint64, headers chan<- types.Header) error {
+	current := startBlock
+	retryInterval := time.Duration(6) * time.Second
+	for {
+		select {
+		case <-ctx.Done():
+			li.log.Info("Shutting down producer of finalized headers")
+			return ctx.Err()
+		default:
+			finalizedHash, err := li.conn.api.RPC.Chain.GetFinalizedHead()
+			if err != nil {
+				li.log.WithError(err).Error("Failed to fetch finalized head")
+				return err
+			}
+
+			finalizedHeader, err := li.conn.api.RPC.Chain.GetHeader(finalizedHash)
+			if err != nil {
+				li.log.WithError(err).Error("Failed to fetch header for finalized head")
+				return err
+			}
+
+			if current > uint64(finalizedHeader.Number) {
+				li.log.WithFields(logrus.Fields{
+					"block":  current,
+					"latest": finalizedHeader.Number,
+				}).Trace("Block is not yet finalized")
+				sleep(ctx, retryInterval)
+				continue
+			}
+
+			hash, err := li.conn.api.RPC.Chain.GetBlockHash(current)
+			if err != nil {
+				if err.Error() == ErrBlockNotReady.Error() {
+					sleep(ctx, retryInterval)
+					continue
+				} else {
+					li.log.WithError(err).Error("Failed to fetch block hash")
+					return err
+				}
+			}
+
+			header, err := li.conn.api.RPC.Chain.GetHeader(hash)
+			if err != nil {
+				li.log.WithError(err).Error("Failed to fetch header")
+				return err
+			}
+
+			headers <- *header
+			current = current + 1
+		}
+	}
+}
+
+func (li *Listener) consumeFinalizedHeaders(ctx context.Context, headers <-chan types.Header) error {
+	if li.messages == nil {
+		li.log.Info("Not polling events since channel is nil")
+		return nil
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			li.log.Info("Shutting down consumer of finalized headers")
+			return ctx.Err()
+		case header, ok := <-headers:
+			// check if headers channel has closed
+			if !ok {
+				return nil
+			}
+			err := li.processHeader(ctx, header)
+			if err != nil {
+				return err
+			}
+		}
+	}
+}
+
+func (li *Listener) processHeader(ctx context.Context, header types.Header) error {
+
+	li.log.WithFields(logrus.Fields{
+		"blockNumber": header.Number,
+	}).Debug("Processing block")
+
+	digestItem, err := getAuxiliaryDigestItem(header.Digest)
+	if err != nil {
+		return err
+	}
+
+	if digestItem == nil || !digestItem.IsCommitment {
+		return nil
+	}
+
+	li.log.WithFields(logrus.Fields{
+		"block":          header.Number,
+		"channelID":      digestItem.AsCommitment.ChannelID,
+		"commitmentHash": digestItem.AsCommitment.Hash.Hex(),
+	}).Debug("Found commitment hash in header digest")
+
+	storageKey, err := MakeStorageKey(digestItem.AsCommitment.ChannelID, digestItem.AsCommitment.Hash)
+	if err != nil {
+		return err
+	}
+
+	data, err := li.conn.api.RPC.Offchain.LocalStorageGet(rpcOffchain.Persistent, storageKey)
+	if err != nil {
+		li.log.WithError(err).Error("Failed to read commitment from offchain storage")
+		return err
+	}
+
+	if data != nil {
+		li.log.WithFields(logrus.Fields{
+			"block":               header.Number,
+			"commitmentSizeBytes": len(*data),
+		}).Debug("Retrieved commitment from offchain storage")
+	} else {
+		li.log.WithError(err).Error("Commitment not found in offchain storage")
+		return err
+	}
+
+	var messages []chainTypes.CommitmentMessage
+
+	err = types.DecodeFromBytes(*data, &messages)
+	if err != nil {
+		li.log.WithError(err).Error("Failed to decode commitment messages")
+		return err
+	}
+
+	message := chain.SubstrateOutboundMessage{
+		ChannelID:      digestItem.AsCommitment.ChannelID,
+		CommitmentHash: digestItem.AsCommitment.Hash,
+		Commitment:     messages,
+	}
+
+	li.messages <- []chain.Message{message}
+
+	return nil
 }
 
 func getAuxiliaryDigestItem(digest types.Digest) (*chainTypes.AuxiliaryDigestItem, error) {

--- a/test/README.md
+++ b/test/README.md
@@ -46,11 +46,32 @@ git checkout enable_beefy_on_rococo
 cargo build --release
 ```
 
+Check that all related services are not running (eg: from a previous run):
+```
+ps -aux | grep polkadot
+ps -aux | grep ganache
+ps -aux | grep substrate
+```
+
+Kill all processes that are still running if needed
+```
+kill -9 ...
+```
+
 Start all services (parachain, relayer, ganache, etc):
 
 ```bash
 scripts/start-services.sh
 ```
+
+Wait until the "System has been initialized" message
+
+Go to polkadot-js and wait until the parachain has started producing blocks:
+https://polkadot.js.org/apps/?rpc=ws%3A%2F%2F127.0.0.1%3A11144#/explorer
+
+Confirm the block number is > 2
+
+You should now be good to go!
 
 ## Run Tests
 

--- a/test/package.json
+++ b/test/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "license": "MIT",
   "scripts": {
-    "test": "mocha --timeout 80000 --exit"
+    "test": "mocha --timeout 120000 --exit"
   },
   "dependencies": {
     "@polkadot/api": "^4.4.1",

--- a/test/scripts/start-services.sh
+++ b/test/scripts/start-services.sh
@@ -95,7 +95,7 @@ start_relayer()
 
     mage build
 
-    export ARTEMIS_ETHEREUM_KEY="0x4e9444a6efd6d42725a250b650a781da2737ea308c839eaccb0f7f3dbd2fea77"
+    export ARTEMIS_ETHEREUM_KEY="0x935b65c833ced92c43ef9de6bff30703d941bd92a2637cb00cfad389f5862109"
     export ARTEMIS_PARACHAIN_KEY="//Relay"
     export ARTEMIS_RELAYCHAIN_KEY="//Alice"
 

--- a/test/scripts/start-services.sh
+++ b/test/scripts/start-services.sh
@@ -15,7 +15,7 @@ start_ganache()
         --mnemonic='stone speak what ritual switch pigeon weird dutch burst shaft nature shove' \
         >ganache.log 2>&1 &
 
-    scripts/wait-for-it.sh -t 20 localhost:8545
+    scripts/wait-for-it.sh -t 32 localhost:8545
     sleep 5
 }
 
@@ -82,7 +82,7 @@ start_parachain()
 
     popd
 
-    scripts/wait-for-it.sh -t 20 localhost:11144
+    scripts/wait-for-it.sh -t 32 localhost:11144
     echo "Waiting for consensus between polkadot and parachain"
     sleep 60
 }

--- a/test/src/ethclient/index.js
+++ b/test/src/ethclient/index.js
@@ -41,7 +41,7 @@ class EthClient {
 
   async initialize() {
     this.accounts = await this.web3.eth.getAccounts();
-    this.web3.eth.defaultAccount = this.accounts[0];
+    this.web3.eth.defaultAccount = this.accounts[1];
 
     const snowDotAddr = await this.appDOT.methods.token().call();
     const snowDOT = new this.web3.eth.Contract(WrappedToken.abi, snowDotAddr);

--- a/test/test/test.js
+++ b/test/test/test.js
@@ -187,7 +187,7 @@ describe('Bridge', function () {
       let beforeEthBalance = await ethClient.getErc20Balance(account);
       let beforeSubBalance = await subClient.queryAssetBalance(polkadotRecipientSS58, this.erc20AssetId);
 
-      await subClient.burnERC20(subClient.alice, TestTokenAddress, account, amount.toFixed(), 1)
+      await subClient.burnERC20(subClient.alice, TestTokenAddress, account, amount.toFixed(), 0)
       await sleep(70000);
 
       let afterEthBalance = await ethClient.getErc20Balance(account);

--- a/test/test/test.js
+++ b/test/test/test.js
@@ -51,7 +51,7 @@ describe('Bridge', function () {
 
       // lock DOT using basic channel
       await subClient.lockDOT(subClient.alice, account, amount.toFixed(), 0)
-      await sleep(70000);
+      await sleep(90000);
 
       let afterEthBalance = await ethClient.getDotBalance(account);
       let afterSubBalance = await subClient.queryAccountBalance(polkadotSenderSS58);
@@ -71,7 +71,7 @@ describe('Bridge', function () {
       let beforeSubBalance = await subClient.queryAccountBalance(polkadotRecipientSS58);
 
       await ethClient.burnDOT(account, amountWrapped, polkadotRecipient, 0);
-      await sleep(70000);
+      await sleep(60000);
 
       let afterEthBalance = await ethClient.getDotBalance(account);
       let afterSubBalance = await subClient.queryAccountBalance(polkadotRecipientSS58);
@@ -95,7 +95,7 @@ describe('Bridge', function () {
       let beforeTreasuryBalance = await subClient.queryAccountBalance("5EYCAe5jHEaRUtbinpdbTLuTyGiVt2TJGQPi9fdvVpNLNfSS");
 
       await ethClient.burnDOT(account, amountWrapped, polkadotRecipient, 1);
-      await sleep(70000);
+      await sleep(60000);
 
       let afterEthBalance = await ethClient.getDotBalance(account);
       let afterSubBalance = await subClient.queryAccountBalance(polkadotRecipientSS58);
@@ -118,8 +118,7 @@ describe('Bridge', function () {
       const beforeSubBalance = await subClient.queryAssetBalance(polkadotRecipientSS58, this.ethAssetId);
 
       const { gasCost } = await ethClient.lockETH(account, amount, polkadotRecipient);
-
-      await sleep(50000);
+      await sleep(60000);
 
       const afterEthBalance = await ethClient.getEthBalance(account);
       const afterSubBalance = await subClient.queryAssetBalance(polkadotRecipientSS58, this.ethAssetId);
@@ -141,7 +140,7 @@ describe('Bridge', function () {
       let beforeSubBalance = await subClient.queryAssetBalance(polkadotRecipientSS58, this.ethAssetId);
 
       await subClient.burnETH(subClient.alice, account, amount.toFixed(), 0)
-      await sleep(70000);
+      await sleep(90000);
 
       let afterEthBalance = await ethClient.getEthBalance(account);
       let afterSubBalance = await subClient.queryAssetBalance(polkadotRecipientSS58, this.ethAssetId);
@@ -159,15 +158,14 @@ describe('Bridge', function () {
     it('should transfer ERC20 tokens from Ethereum to Substrate', async function () {
       let amount = BigNumber('1000');
 
-      const account = ethClient.accounts[0];
+      const account = ethClient.accounts[1];
 
       let beforeEthBalance = await ethClient.getErc20Balance(account);
       let beforeSubBalance = await subClient.queryAssetBalance(polkadotRecipientSS58, this.erc20AssetId);
 
       await ethClient.approveERC20(account, amount);
       await ethClient.lockERC20(account, amount, polkadotRecipient);
-
-      await sleep(50000);
+      await sleep(60000);
 
       let afterEthBalance = await ethClient.getErc20Balance(account);
       let afterSubBalance = await subClient.queryAssetBalance(polkadotRecipientSS58, this.erc20AssetId);
@@ -182,13 +180,13 @@ describe('Bridge', function () {
     it('should transfer ERC20 from Substrate to Ethereum', async function () {
       let amount = BigNumber('1000');
 
-      const account = ethClient.accounts[0];
+      const account = ethClient.accounts[1];
 
       let beforeEthBalance = await ethClient.getErc20Balance(account);
       let beforeSubBalance = await subClient.queryAssetBalance(polkadotRecipientSS58, this.erc20AssetId);
 
       await subClient.burnERC20(subClient.alice, TestTokenAddress, account, amount.toFixed(), 0)
-      await sleep(70000);
+      await sleep(90000);
 
       let afterEthBalance = await ethClient.getErc20Balance(account);
       let afterSubBalance = await subClient.queryAssetBalance(polkadotRecipientSS58, this.erc20AssetId);


### PR DESCRIPTION
This improves the reliability of the relay and E2E tests in several aspects.

### More reliable substrate listener
The substrate listener has been rewritten and no longer occasionally skips blocks.

There was a bug in the previous implementation where we looked for the commitment digest item in the wrong block:
https://github.com/Snowfork/polkadot-ethereum/blob/ce403c921100a516eb3699cadb8cc05827bf10ea/relayer/chain/parachain/listener.go#L97
It should have been the header corresponding to `currentBlock` not `finalizedHeader`.

Anyway, the listener has now been factored into 3 logical parts for conceptual clarity:
1) A mechanism to determine the starting block. In future we can swap in different implementations as we see fit.
2) A producer of finalized blocks
3) A consumer of finalized blocks

### No more deadlocks
Not really an immediate issue but was worth sorting out. By properly closing channels when appropriate, there should no longer be any deadlocks. So hopefully no more need for the deadlock breaker mechanism.

### Ethereum listener now fails-fast on more error conditions

Previously it would just skip over some errors, ignore them and move onto the next block.

### Fixed various E2E test issues causing non-deterministic failures

* Relayer now uses account 9 for submitting transactions to Ethereum
* Adjust timeouts and other random stuff.

E2E test have now passed 3 times in a row on my machine.