### PR TITLE
Housekeeping: Convert dot-app pallet to new pallet syntax

### DIFF
--- a/parachain/pallets/dot-app/Cargo.toml
+++ b/parachain/pallets/dot-app/Cargo.toml
@@ -33,7 +33,6 @@ artemis-dispatch = { path = "../../pallets/dispatch"  }
 sp-keyring = { git = "https://github.com/paritytech/substrate.git", branch = "rococo-v1" }
 pallet-balances = { git = "https://github.com/paritytech/substrate.git", branch = "rococo-v1" }
 
-
 [features]
 default = ["std"]
 std = [

--- a/parachain/pallets/dot-app/src/lib.rs
+++ b/parachain/pallets/dot-app/src/lib.rs
@@ -75,6 +75,7 @@ pub mod pallet {
 	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
 		// Verify that `T::Decimals` is 10 (DOT), or 12 (KSM) to guarantee
 		// safe conversions between native and wrapped DOT.
+		#[cfg(feature = "std")]
 		fn integrity_test() {
 			sp_io::TestExternalities::new_empty().execute_with(|| {
 				let allowed_decimals: &[u32] = &[10, 12];

--- a/parachain/pallets/dot-app/src/mock.rs
+++ b/parachain/pallets/dot-app/src/mock.rs
@@ -12,6 +12,7 @@ use sp_runtime::{
     traits::{BlakeTwo256, IdentifyAccount, IdentityLookup, Verify},
     ModuleId, MultiSignature,
 };
+use frame_support::traits::GenesisBuild;
 
 use artemis_core::{ChannelId, OutboundRouter};
 
@@ -29,7 +30,7 @@ frame_support::construct_runtime!(
         System: frame_system::{Pallet, Call, Storage, Event<T>},
         Balances: pallet_balances::{Pallet, Call, Storage, Event<T>},
         Dispatch: artemis_dispatch::{Pallet, Call, Storage, Origin, Event<T>},
-        DOTApp: dot_app::{Pallet, Call, Config, Storage, Event<T>},
+        DOTApp: dot_app::{Pallet, Call, Config<T>, Storage, Event<T>},
     }
 );
 
@@ -125,9 +126,11 @@ pub fn new_tester() -> sp_io::TestExternalities {
         .build_storage::<Test>()
         .unwrap();
 
-    let config = dot_app::GenesisConfig {
+    let config: dot_app::GenesisConfig<Test> = dot_app::GenesisConfig {
         address: H160::repeat_byte(1),
+        phantom: Default::default(),
     };
+
     config.assimilate_storage(&mut storage).unwrap();
 
     let mut ext: sp_io::TestExternalities = storage.into();

--- a/parachain/pallets/dot-app/src/weights.rs
+++ b/parachain/pallets/dot-app/src/weights.rs
@@ -1,0 +1,11 @@
+use frame_support::weights::Weight;
+
+pub trait WeightInfo {
+    fn lock() -> Weight;
+    fn unlock() -> Weight;
+}
+
+impl WeightInfo for () {
+    fn lock() -> Weight { 0 }
+    fn unlock() -> Weight { 0 }
+}

--- a/parachain/pallets/incentivized-channel/Cargo.toml
+++ b/parachain/pallets/incentivized-channel/Cargo.toml
@@ -23,7 +23,6 @@ sp-std = { git = "https://github.com/paritytech/substrate.git", branch = "rococo
 sp-runtime = { git = "https://github.com/paritytech/substrate.git", branch = "rococo-v1", default-features = false }
 sp-io = { git = "https://github.com/paritytech/substrate.git", branch = "rococo-v1", default-features = false }
 
-
 artemis-core = { path = "../../primitives/core", default-features = false }
 artemis-ethereum = { path = "../../primitives/ethereum", default-features = false }
 ethabi = { git = "https://github.com/Snowfork/ethabi-decode.git", package = "ethabi-decode", branch = "master", default-features = false }
@@ -44,6 +43,7 @@ std = [
     "sp-core/std",
     "sp-runtime/std",
     "sp-std/std",
+    "sp-io/std",
     "artemis-core/std",
     "artemis-ethereum/std",
     "ethabi/std"

--- a/parachain/runtime/local/src/lib.rs
+++ b/parachain/runtime/local/src/lib.rs
@@ -553,7 +553,7 @@ construct_runtime!(
 		Transfer: artemis_transfer::{Pallet, Call, Event<T>} = 16,
 		Utility: pallet_utility::{Pallet, Call, Event, Storage} = 17,
 
-		DOT: dot_app::{Pallet, Call, Config, Storage, Event<T>} = 64,
+		DOT: dot_app::{Pallet, Call, Config<T>, Storage, Event<T>} = 64,
 		ETH: eth_app::{Pallet, Call, Config, Storage, Event<T>} = 65,
 		ERC20: erc20_app::{Pallet, Call, Config, Storage, Event<T>} = 66,
 	}

--- a/parachain/runtime/rococo/src/lib.rs
+++ b/parachain/runtime/rococo/src/lib.rs
@@ -555,7 +555,7 @@ construct_runtime!(
 		Transfer: artemis_transfer::{Pallet, Call, Event<T>} = 16,
 		Utility: pallet_utility::{Pallet, Call, Event, Storage} = 17,
 
-		DOT: dot_app::{Pallet, Call, Config, Storage, Event<T>} = 64,
+		DOT: dot_app::{Pallet, Call, Config<T>, Storage, Event<T>} = 64,
 		ETH: eth_app::{Pallet, Call, Config, Storage, Event<T>} = 65,
 		ERC20: erc20_app::{Pallet, Call, Config, Storage, Event<T>} = 66,
 	}

--- a/parachain/runtime/snowbridge/src/lib.rs
+++ b/parachain/runtime/snowbridge/src/lib.rs
@@ -556,7 +556,7 @@ construct_runtime!(
 		Transfer: artemis_transfer::{Pallet, Call, Event<T>} = 16,
 		Utility: pallet_utility::{Pallet, Call, Event, Storage} = 17,
 
-		DOT: dot_app::{Pallet, Call, Config, Storage, Event<T>} = 64,
+		DOT: dot_app::{Pallet, Call, Config<T>, Storage, Event<T>} = 64,
 		ETH: eth_app::{Pallet, Call, Config, Storage, Event<T>} = 65,
 		ERC20: erc20_app::{Pallet, Call, Config, Storage, Event<T>} = 66,
 	}

--- a/parachain/src/chain_spec/local.rs
+++ b/parachain/src/chain_spec/local.rs
@@ -164,7 +164,8 @@ fn testnet_genesis(
 			address: hex!["83428c7db9815f482a39a1715684dCF755021997"].into()
 		},
 		dot_app: DOTConfig {
-			address: hex!["b1185ede04202fe62d38f5db72f71e38ff3e8305"].into()
+			address: hex!["b1185ede04202fe62d38f5db72f71e38ff3e8305"].into(),
+			phantom: Default::default(),
 		},
 		parachain_info: ParachainInfoConfig { parachain_id: para_id },
 	}

--- a/parachain/src/chain_spec/rococo.rs
+++ b/parachain/src/chain_spec/rococo.rs
@@ -164,7 +164,8 @@ fn testnet_genesis(
 			address: hex!["83428c7db9815f482a39a1715684dCF755021997"].into()
 		},
 		dot_app: DOTConfig {
-			address: hex!["b1185ede04202fe62d38f5db72f71e38ff3e8305"].into()
+			address: hex!["b1185ede04202fe62d38f5db72f71e38ff3e8305"].into(),
+			phantom: Default::default(),
 		},
 		parachain_info: ParachainInfoConfig { parachain_id: para_id },
 	}

--- a/parachain/src/chain_spec/snowbridge.rs
+++ b/parachain/src/chain_spec/snowbridge.rs
@@ -164,7 +164,8 @@ fn testnet_genesis(
 			address: hex!["83428c7db9815f482a39a1715684dCF755021997"].into()
 		},
 		dot_app: DOTConfig {
-			address: hex!["b1185ede04202fe62d38f5db72f71e38ff3e8305"].into()
+			address: hex!["b1185ede04202fe62d38f5db72f71e38ff3e8305"].into(),
+			phantom: Default::default(),
 		},
 		parachain_info: ParachainInfoConfig { parachain_id: para_id },
 	}


### PR DESCRIPTION
The pallet `decl_*` macros have been deprecated in favour of the new [frame_support::pallet](https://substrate.dev/rustdocs/v3.0.0/frame_support/attr.pallet.html) macros.

These new macros are more idiomatic Rust, improve editor Intellisense, and are more compatible with auto-formatters such as [rustfmt](https://github.com/rust-lang/rustfmt).

My goal is to convert 1 pallet each week, in between other work.

E2E tests are all green.