### PR TITLE
Minor fixes to startscript

### DIFF
--- a/ethereum/.gitignore
+++ b/ethereum/.gitignore
@@ -3,3 +3,5 @@ build**
 .env
 
 node_modules/
+
+ganache.log

--- a/relayer/magefile.go
+++ b/relayer/magefile.go
@@ -34,5 +34,5 @@ func Dev() error {
 		"ARTEMIS_PARACHAIN_KEY":  "//Relay",
 		"ARTEMIS_RELAYCHAIN_KEY": "//Alice",
 	}
-	return sh.RunWithV(env, cmd, "run", "./main.go", "run", "--config", "$configdir/config.toml")
+	return sh.RunWithV(env, cmd, "run", "./main.go", "run", "--config", "/tmp/snowbridge-e2e-config/config.toml")
 }

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -6,3 +6,4 @@ relay.log
 alice.log
 bob.log
 200.log
+tmp

--- a/test/README.md
+++ b/test/README.md
@@ -14,6 +14,7 @@ The E2E tests run against local deployments of the parachain, relayer and ganach
 
 3. Development environment for Relayer. See relayer [requirements](../relayer/README.md#requirements).
 4. `timeout` - native package on Ubuntu, on macOS try ```brew install coreutils```
+5. `jq` - https://stedolan.github.io/jq/download/
 5. Build the `@snowfork/snowbridge-types` package using these [steps](../types/README.md#development).
 
 ## Setup
@@ -44,18 +45,6 @@ git clone -n https://github.com/snowfork/polkadot.git /tmp/polkadot
 cd /tmp/polkadot
 git checkout enable_beefy_on_rococo
 cargo build --release
-```
-
-Check that all related services are not running (eg: from a previous run):
-```
-ps -aux | grep polkadot
-ps -aux | grep ganache
-ps -aux | grep artemis
-```
-
-Kill all processes that are still running if needed
-```
-kill -9 ...
 ```
 
 Start all services (parachain, relayer, ganache, etc):

--- a/test/config/launchConfigOverrides.json
+++ b/test/config/launchConfigOverrides.json
@@ -1,0 +1,18 @@
+{
+  "parachains": [
+    {
+      "id": "200",
+      "wsPort": 11144,
+      "port": 31200,
+      "flags": [
+        "--execution=native",
+        "-lruntime=debug,import_header=trace,bridge=trace",
+        "--rpc-cors=all",
+        "--offchain-worker=Always",
+        "--enable-offchain-indexing=true",
+        "--",
+        "--execution=wasm"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
some highlights:
 - clear and use same tmp folder each time so that can easily run relayer or other parts separately without having to copy paste folder
 - autocleaning of leftover processes
 - start ganache with 0 blocktime during contract deployment for quick deployment, then restart it for slower blocks
 - clean up config replacement stuff