### PR TITLE
Overhaul channels & shutdown sequence to avoid deadlocks

### DIFF
--- a/relayer/workers/ethrelayer/main.go
+++ b/relayer/workers/ethrelayer/main.go
@@ -11,7 +11,6 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/snowfork/go-substrate-rpc-client/v2/types"
-	"github.com/snowfork/polkadot-ethereum/relayer/chain"
 	"github.com/snowfork/polkadot-ethereum/relayer/chain/ethereum"
 	"github.com/snowfork/polkadot-ethereum/relayer/chain/parachain"
 	"github.com/snowfork/polkadot-ethereum/relayer/crypto/sr25519"
@@ -52,23 +51,18 @@ func (w *Worker) Start(ctx context.Context, eg *errgroup.Group) error {
 		return nil
 	})
 
-	// channel for messages from ethereum
-	ethMessages := make(chan []chain.Message, 1)
-	// channel for headers from ethereum (it's a blocking channel so that we
-	// can guarantee that a header is forwarded before we send dependent messages)
-	ethHeaders := make(chan chain.Header)
+	// channel for payloads from ethereum
+	payloads := make(chan ParachainPayload, 1)
 
 	listener := NewEthereumListener(
 		w.ethconfig,
 		w.ethconn,
-		ethMessages,
-		ethHeaders,
+		payloads,
 		w.log,
 	)
 	writer := NewParachainWriter(
 		w.paraconn,
-		ethMessages,
-		ethHeaders,
+		payloads,
 		w.log,
 	)
 

--- a/relayer/workers/ethrelayer/parachain-writer_test.go
+++ b/relayer/workers/ethrelayer/parachain-writer_test.go
@@ -27,13 +27,12 @@ func TestWrite(t *testing.T) {
 
 	conn := parachain.NewConnection("ws://127.0.0.1:11144/", sr25519.Alice().AsKeyringPair(), log)
 
-	messages := make(chan []chain.Message, 1)
-	headers := make(chan chain.Header, 1)
+	payloads := make(chan ethrelayer.ParachainPayload, 1)
 	ctx, cancel := context.WithCancel(context.Background())
 	eg, ctx := errgroup.WithContext(ctx)
 	defer cancel()
 
-	writer := ethrelayer.NewParachainWriter(conn, messages, headers, log)
+	writer := ethrelayer.NewParachainWriter(conn, payloads, log)
 
 	err := conn.Connect(ctx)
 	if err != nil {

--- a/relayer/workers/worker.go
+++ b/relayer/workers/worker.go
@@ -68,7 +68,7 @@ func (wp WorkerPool) runWorker(ctx context.Context, worker Worker, log *logrus.E
 }
 
 func (wp WorkerPool) Run() error {
-	return wp.run(context.Background(), wp.getDefaultLogger())
+	return wp.run(context.Background(), wp.defaultLogger())
 }
 
 func (wp WorkerPool) RunWithContext(ctx context.Context, log *logrus.Entry) error {
@@ -124,6 +124,6 @@ func (wp WorkerPool) run(ctx context.Context, log *logrus.Entry) error {
 	return eg.Wait()
 }
 
-func (wp WorkerPool) getDefaultLogger() *logrus.Entry {
+func (wp WorkerPool) defaultLogger() *logrus.Entry {
 	return logrus.WithField("source", "WorkerPool")
 }

--- a/relayer/workers/worker.go
+++ b/relayer/workers/worker.go
@@ -49,7 +49,7 @@ func (wp WorkerPool) runWorker(ctx context.Context, worker Worker, log *logrus.E
 		// Goroutines are either shutting down or deadlocked.
 		// Give them a few seconds...
 		select {
-		case <-time.After(3 * time.Second):
+		case <-time.After(10 * time.Second):
 			break
 		case err := <-notifyWaitDone:
 			// All goroutines have ended

--- a/relayer/workers/worker_test.go
+++ b/relayer/workers/worker_test.go
@@ -1,0 +1,59 @@
+// Copyright 2021 Snowfork
+// SPDX-License-Identifier: LGPL-3.0-only
+
+package workers_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	logtest "github.com/sirupsen/logrus/hooks/test"
+
+	"github.com/snowfork/polkadot-ethereum/relayer/workers"
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/sync/errgroup"
+)
+
+type TestWorker struct{}
+
+func (w *TestWorker) Name() string { return "TestWorker" }
+
+func (w *TestWorker) Start(ctx context.Context, eg *errgroup.Group) error {
+	eg.Go(func() error {
+		<-ctx.Done()
+		return ctx.Err()
+	})
+	return nil
+}
+
+func TestCanStopPool(t *testing.T) {
+	factory := func() (workers.Worker, error) { return &TestWorker{}, nil }
+	pool := workers.WorkerPool{
+		factory,
+		factory,
+		factory,
+	}
+
+	logger, hook := logtest.NewNullLogger()
+	logger.SetLevel(logrus.DebugLevel)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	errCh := make(chan error)
+	go func() {
+		errCh <- pool.RunWithContext(ctx, logger.WithField("source", "TestWorkerPool"))
+	}()
+
+	<-time.After(100 * time.Millisecond)
+	cancel()
+	terminalErr := <-errCh
+
+	assert.Equal(t, errors.New("context canceled"), terminalErr)
+	// 3 starts followed by 3 stops should have been logged
+	assert.Equal(t, 6, len(hook.AllEntries()))
+	assert.Equal(t, hook.AllEntries()[2].Message, "Starting worker")
+	assert.Equal(t, hook.LastEntry().Message, "Worker terminated")
+}


### PR DESCRIPTION
This PR overhauls the way that `ethrelayer.ParachainWriter`, `ethrelayer.EthereumListener` and `ethereum.Syncer` use channels in order to get rid of deadlocks. Again. The changes I'm making:
* The writer & listener communicate via a single channel `payloads`.
  * A deadlock could occur when the writer was waiting for `headers` to be closed while the listener was trying to send to `messages`. **Generally, a producer goroutine should send to a single channel**.
* The syncer now uses a channel for each goroutine, i.e. `pollNewHeaders` sends to `newHeaders` and `fetchFinalizedHeaders` sends to `oldHeaders`. A new goroutine forwards `oldHeaders` and `newHeaders` to the outgoing `headers` channel.
  * This solves the problem where closing the `headers` channel in one goroutine could cause a panic in the other goroutine since it was sending to the same channel. So closing channels cleanly was impossible.
* Consumer goroutines iterate over incoming channels until the channel is closed using `for range channel`
  * This wasn't happening consistently for all consumers. All this logic is now in the `Start` function so that it's easy to audit.