### PR TITLE
Fix default location of polkadot binary

### DIFF
--- a/test/.env-example
+++ b/test/.env-example
@@ -1,1 +1,1 @@
-polkadotbinary=/tmp/polkadot
+polkadotbinary=/tmp/polkadot/target/release/polkadot

--- a/test/README.md
+++ b/test/README.md
@@ -30,7 +30,12 @@ yarn install
 Install `polkadot-launch`:
 
 ```bash
-yarn global add polkadot-launch@1.4.0
+git clone -n https://github.com/paritytech/polkadot-launch.git /tmp/polkadot-launch
+cd /tmp/polkadot-launch
+git checkout 89e970
+yarn install
+yarn build
+yarn global add file:$(pwd)
 ```
 
 Build polkadot:

--- a/test/README.md
+++ b/test/README.md
@@ -19,23 +19,18 @@ The E2E tests run against local deployments of the parachain, relayer and ganach
 
 ## Setup
 
+Make sure to install/build all the requirements above.
+
 Download dependencies:
 
 ```bash
 yarn install
-
-# Build typescript bindings
-cd ./node_modules/@snowfork/snowbridge-types && yarn install
 ```
 
 Install `polkadot-launch`:
 
 ```bash
-git clone -n https://github.com/paritytech/polkadot-launch.git /tmp/polkadot-launch
-cd /tmp/polkadot-launch
-yarn install
-yarn build
-yarn global add file:$(pwd)
+yarn global add polkadot-launch@1.4.0
 ```
 
 Build polkadot:
@@ -47,8 +42,8 @@ git checkout enable_beefy_on_rococo
 cargo build --release
 ```
 
-Create your test env file to set the directory where you installed the polkadot binary.
-You can modify it if you installed polkadot elsewhere.
+Optional: If you cloned the polkadot repo in another location, Create an `.env` file to specify the directory where you installed the polkadot binary.
+
 ```bash
 cp ./.env-example .env
 ```

--- a/test/scripts/start-services.sh
+++ b/test/scripts/start-services.sh
@@ -84,7 +84,9 @@ start_parachain()
 
     echo "Writing Polkadot configuration"
     polkadotbinary=/tmp/polkadot/target/release/polkadot
-    source ../test/.env
+    if [[ -f ../test/.env ]]; then
+        source ../test/.env
+    fi
     jq  -s '.[0] * .[1]' config.json ../test/config/launchConfigOverrides.json \
         | jq ".parachains[0].bin = \"$bin\"" \
         | jq ".parachains[0].chain = \"$configdir/spec.json\"" \

--- a/test/scripts/start-services.sh
+++ b/test/scripts/start-services.sh
@@ -83,7 +83,7 @@ start_parachain()
         para_id 200
 
     echo "Writing Polkadot configuration"
-    polkadotbinary=/tmp/polkadot
+    polkadotbinary=/tmp/polkadot/target/release/polkadot
     source ../test/.env
     jq  -s '.[0] * .[1]' config.json ../test/config/launchConfigOverrides.json \
         | jq ".parachains[0].bin = \"$bin\"" \


### PR DESCRIPTION
This was causing start-services to fail unless an `.env` file was in place. That should be optional.

Also misc updates for README and polkadot-launch