### PR TITLE
Restart workers & improved deadlock handling

### DIFF
--- a/ethereum/scripts/dumpTestConfig.js
+++ b/ethereum/scripts/dumpTestConfig.js
@@ -60,9 +60,16 @@ const dump = (tmpDir, channels, bridge) => {
             dbpath: "tmp.db",
         },
         workers: {
-            parachaincommitmentrrelayer: true,
-            beefyrelayer: true,
-            ethrelayer: true
+            parachaincommitmentrelayer: {
+                enabled: true,
+            },
+            beefyrelayer:  {
+                enabled: true,
+            },
+            ethrelayer:  {
+                enabled: true,
+                "restart-delay": 60,
+            },
         }
     }
     fs.writeFileSync(path.join(tmpDir, "config.toml"), TOML.stringify(config));

--- a/relayer/core/relay.go
+++ b/relayer/core/relay.go
@@ -20,6 +20,7 @@ import (
 	"github.com/snowfork/polkadot-ethereum/relayer/chain/ethereum"
 	"github.com/snowfork/polkadot-ethereum/relayer/chain/parachain"
 	"github.com/snowfork/polkadot-ethereum/relayer/chain/relaychain"
+	"github.com/snowfork/polkadot-ethereum/relayer/workers"
 	"github.com/snowfork/polkadot-ethereum/relayer/workers/beefyrelayer"
 	"github.com/snowfork/polkadot-ethereum/relayer/workers/beefyrelayer/store"
 	"github.com/snowfork/polkadot-ethereum/relayer/workers/ethrelayer"
@@ -33,9 +34,9 @@ type Relay struct {
 }
 
 type WorkerConfig struct {
-	ParachainCommitmentRelayer bool `mapstructure:"parachaincommitmentrrelayer"`
-	BeefyRelayer               bool `mapstructure:"beefyrelayer"`
-	EthRelayer                 bool `mapstructure:"ethrelayer"`
+	ParachainCommitmentRelayer workers.WorkerConfig `mapstructure:"parachaincommitmentrelayer"`
+	BeefyRelayer               workers.WorkerConfig `mapstructure:"beefyrelayer"`
+	EthRelayer                 workers.WorkerConfig `mapstructure:"ethrelayer"`
 }
 
 type Config struct {
@@ -54,7 +55,7 @@ func NewRelay() (*Relay, error) {
 
 	parachainCommitmentRelayer := &parachaincommitmentrelayer.Worker{}
 
-	if config.Workers.ParachainCommitmentRelayer == true {
+	if config.Workers.ParachainCommitmentRelayer.Enabled {
 		parachainCommitmentRelayer, err = parachaincommitmentrelayer.NewWorker(&config.Parachain, &config.Relaychain, &config.Eth)
 		if err != nil {
 			return nil, err
@@ -63,7 +64,7 @@ func NewRelay() (*Relay, error) {
 
 	beefyRelayer := &beefyrelayer.Worker{}
 
-	if config.Workers.BeefyRelayer == true {
+	if config.Workers.BeefyRelayer.Enabled {
 		beefyRelayer, err = beefyrelayer.NewWorker(&config.Relaychain, &config.Eth, &config.BeefyRelayerDatabase)
 		if err != nil {
 			return nil, err
@@ -72,7 +73,7 @@ func NewRelay() (*Relay, error) {
 
 	ethRelayer := &ethrelayer.Worker{}
 
-	if config.Workers.EthRelayer == true {
+	if config.Workers.EthRelayer.Enabled {
 		ethRelayer = ethrelayer.NewWorker(
 			&config.Eth,
 			&config.Parachain,

--- a/relayer/core/relayV2.go
+++ b/relayer/core/relayV2.go
@@ -18,12 +18,12 @@ func (re *RelayV2) Run() error {
 		return err
 	}
 
-	ethrelayerFactory := func() (workers.Worker, error) {
+	ethrelayerFactory := func() (workers.Worker, *workers.WorkerConfig, error) {
 		return ethrelayer.NewWorker(
 			&config.Eth,
 			&config.Parachain,
 			logrus.WithField("worker", ethrelayer.Name),
-		), nil
+		), &config.Workers.EthRelayer, nil
 	}
 
 	// TODO: add all workers

--- a/relayer/workers/config.go
+++ b/relayer/workers/config.go
@@ -1,0 +1,11 @@
+// Copyright 2021 Snowfork
+// SPDX-License-Identifier: LGPL-3.0-only
+
+package workers
+
+type WorkerConfig struct {
+	// Should this worker run?
+	Enabled bool `mapstructure:"enabled"`
+	// Restart delay in seconds
+	RestartDelay uint `mapstructure:"restart-delay"`
+}

--- a/relayer/workers/worker.go
+++ b/relayer/workers/worker.go
@@ -5,6 +5,7 @@ package workers
 
 import (
 	"context"
+	"errors"
 	"os"
 	"os/signal"
 	"syscall"
@@ -23,7 +24,11 @@ type WorkerFactory func() (Worker, error)
 
 type WorkerPool []WorkerFactory
 
-func (wp WorkerPool) runWorker(ctx context.Context, worker Worker, log *logrus.Entry) error {
+var WorkerDeadlocked = errors.New("Worker deadlocked")
+
+type DeadlockHandler func() error
+
+func (wp WorkerPool) runWorker(ctx context.Context, worker Worker) error {
 	childEg, childCtx := errgroup.WithContext(ctx)
 	err := worker.Start(childCtx, childEg)
 	if err != nil {
@@ -56,28 +61,32 @@ func (wp WorkerPool) runWorker(ctx context.Context, worker Worker, log *logrus.E
 			return err
 		}
 
-		log.WithField(
-			"worker",
-			worker.Name(),
-		).Error("The worker's goroutines are deadlocked. Please fix")
-
-		relayProc, _ := os.FindProcess(os.Getpid())
-		relayProc.Kill()
-		return nil
+		return WorkerDeadlocked
 	}
 }
 
 func (wp WorkerPool) Run() error {
-	return wp.run(context.Background(), wp.defaultLogger())
+	return wp.run(context.Background(), nil, wp.defaultLogger())
 }
 
-func (wp WorkerPool) RunWithContext(ctx context.Context, log *logrus.Entry) error {
-	return wp.run(ctx, log)
+func (wp WorkerPool) RunWithContext(ctx context.Context, onDeadlock DeadlockHandler, log *logrus.Entry) error {
+	return wp.run(ctx, onDeadlock, log)
 }
 
-func (wp WorkerPool) run(ctx context.Context, log *logrus.Entry) error {
+func (wp WorkerPool) run(ctx context.Context, onDeadlock DeadlockHandler, log *logrus.Entry) error {
 	ctx, cancel := context.WithCancel(ctx)
 	eg, ctx := errgroup.WithContext(ctx)
+
+	if onDeadlock == nil {
+		onDeadlock = func() error {
+			cancel()
+			// Give other workers time to clean up
+			<-time.After(3 * time.Second)
+			relayProc, _ := os.FindProcess(os.Getpid())
+			relayProc.Kill()
+			return nil
+		}
+	}
 
 	// Ensure clean termination upon SIGINT, SIGTERM
 	eg.Go(func() error {
@@ -107,8 +116,17 @@ func (wp WorkerPool) run(ctx context.Context, log *logrus.Entry) error {
 				}
 
 				log.WithField("worker", worker.Name()).Debug("Starting worker")
-				err = wp.runWorker(ctx, worker, log)
-				log.WithField("worker", worker.Name()).Debug("Worker terminated")
+				err = wp.runWorker(ctx, worker)
+
+				if err == WorkerDeadlocked {
+					log.WithField(
+						"worker",
+						worker.Name(),
+					).Error("The worker's goroutines are deadlocked. Please fix")
+					return onDeadlock()
+				} else {
+					log.WithError(err).WithField("worker", worker.Name()).Debug("Worker terminated")
+				}
 
 				select {
 				case <-ctx.Done():


### PR DESCRIPTION
Changes in this PR:
* Workers now restart, either immediately or after `restart-delay` if configured
* A deadlock handler can be passed to `WorkerPool.RunWithContext`. The default is still to cancel the context -> wait a bit -> kill process. But we can now trivially change that in future