### PR TITLE
Limit bytes in outbound message payload

### DIFF
--- a/parachain/pallets/incentivized-channel/src/outbound/benchmarking.rs
+++ b/parachain/pallets/incentivized-channel/src/outbound/benchmarking.rs
@@ -15,7 +15,7 @@ benchmarks! {
 	// in queue are committed.
 	on_initialize {
 		let m in 1 .. T::MaxMessagesPerCommit::get() as u32;
-		let p in 0 .. 128;
+		let p in 0 .. T::MaxMessagePayloadSize::get() as u32;
 
 		for _ in 0 .. m {
 			let payload: Vec<u8> = (0..).take(p as usize).collect();
@@ -39,7 +39,7 @@ benchmarks! {
 		MessageQueue::append(Message {
 			target: H160::zero(),
 			nonce: 0u64,
-			payload: vec![1u8, 128],
+			payload: vec![1u8; T::MaxMessagePayloadSize::get()],
 		});
 
 		Interval::<T>::put::<T::BlockNumber>(10u32.into());

--- a/parachain/runtime/local/src/lib.rs
+++ b/parachain/runtime/local/src/lib.rs
@@ -477,10 +477,15 @@ impl incentivized_channel_inbound::Config for Runtime {
 	type WeightInfo = ();
 }
 
+parameter_types! {
+	pub const MaxMessagePayloadSize: usize = 256;
+}
+
 impl incentivized_channel_outbound::Config for Runtime {
 	const INDEXING_PREFIX: &'static [u8] = b"commitment";
 	type Event = Event;
 	type Hashing = Keccak256;
+	type MaxMessagePayloadSize = MaxMessagePayloadSize;
 	type MaxMessagesPerCommit = MaxMessagesPerCommit;
 	type WeightInfo = ();
 }

--- a/parachain/runtime/rococo/src/lib.rs
+++ b/parachain/runtime/rococo/src/lib.rs
@@ -478,10 +478,15 @@ impl incentivized_channel_inbound::Config for Runtime {
 	type WeightInfo = weights::incentivized_channel_inbound_weights::WeightInfo<Runtime>;
 }
 
+parameter_types! {
+	pub const MaxMessagePayloadSize: usize = 256;
+}
+
 impl incentivized_channel_outbound::Config for Runtime {
 	const INDEXING_PREFIX: &'static [u8] = b"commitment";
 	type Event = Event;
 	type Hashing = Keccak256;
+	type MaxMessagePayloadSize = MaxMessagePayloadSize;
 	type MaxMessagesPerCommit = MaxMessagesPerCommit;
 	type WeightInfo = weights::incentivized_channel_outbound_weights::WeightInfo<Runtime>;
 }

--- a/parachain/runtime/snowbridge/src/lib.rs
+++ b/parachain/runtime/snowbridge/src/lib.rs
@@ -479,10 +479,15 @@ impl incentivized_channel_inbound::Config for Runtime {
 	type WeightInfo = weights::incentivized_channel_inbound_weights::WeightInfo<Runtime>;
 }
 
+parameter_types! {
+	pub const MaxMessagePayloadSize: usize = 256;
+}
+
 impl incentivized_channel_outbound::Config for Runtime {
 	const INDEXING_PREFIX: &'static [u8] = b"commitment";
 	type Event = Event;
 	type Hashing = Keccak256;
+	type MaxMessagePayloadSize = MaxMessagePayloadSize;
 	type MaxMessagesPerCommit = MaxMessagesPerCommit;
 	type WeightInfo = weights::incentivized_channel_outbound_weights::WeightInfo<Runtime>;
 }


### PR DESCRIPTION
This PR addresses https://github.com/Snowfork/polkadot-ethereum/issues/149. We're no longer storing unbounded message payloads in offchain storage.
