### PR TITLE
Use contract's BEEFY commitment ID in relayer when possible

### DIFF
--- a/ethereum/contracts/LightClientBridge.sol
+++ b/ethereum/contracts/LightClientBridge.sol
@@ -83,7 +83,7 @@ contract LightClientBridge {
 
     uint256 public constant THRESHOLD_NUMERATOR = 2;
     uint256 public constant THRESHOLD_DENOMINATOR = 3;
-    uint256 public constant BLOCK_WAIT_PERIOD = 45;
+    uint256 public constant BLOCK_WAIT_PERIOD = 3;
 
     /**
      * @notice Deploys the LightClientBridge contract
@@ -197,7 +197,11 @@ contract LightClientBridge {
         currentId = currentId.add(1);
     }
 
-    function validatorBitfield(uint256 id) public view returns (uint256[] memory) {
+    function validatorBitfield(uint256 id)
+        public
+        view
+        returns (uint256[] memory)
+    {
         ValidationData storage data = validationData[id];
 
         /**
@@ -212,11 +216,12 @@ contract LightClientBridge {
             (validatorRegistry.numOfValidators() * THRESHOLD_NUMERATOR) /
                 THRESHOLD_DENOMINATOR;
 
-        return Bitfield.randomNBitsFromPrior(
-            getSeed(data),
-            data.validatorClaimsBitfield,
-            requiredNumOfSignatures
-        );
+        return
+            Bitfield.randomNBitsFromPrior(
+                getSeed(data),
+                data.validatorClaimsBitfield,
+                requiredNumOfSignatures
+            );
     }
 
     /**

--- a/relayer/workers/beefyrelayer/beefy-ethereum-listener.go
+++ b/relayer/workers/beefyrelayer/beefy-ethereum-listener.go
@@ -182,7 +182,7 @@ func (li *BeefyEthereumListener) processHistoricalInitialVerificationSuccessfulE
 			generatedPayload := li.simulatePayloadGeneration(*item)
 			if generatedPayload == validationData.CommitmentHash {
 				// Update existing database item
-				li.log.Info(
+				li.log.Infof(
 					"Updating item %s status from 'CommitmentWitnessed' to 'InitialVerificationTxConfirmed'",
 					event.Id,
 				)
@@ -237,7 +237,7 @@ func (li *BeefyEthereumListener) processInitialVerificationSuccessfulEvents(ctx 
 			continue
 		}
 
-		li.log.Info(
+		li.log.Infof(
 			"3: Updating item %s status from 'InitialVerificationTxSent' to 'InitialVerificationTxConfirmed'",
 			event.Id,
 		)
@@ -295,7 +295,7 @@ func (li *BeefyEthereumListener) processHistoricalFinalVerificationSuccessfulEve
 	for _, event := range events {
 		item := li.beefyDB.GetItemByID(event.Id.Int64())
 		if int64(item.ID) == event.Id.Int64() {
-			li.log.Info(
+			li.log.Infof(
 				"Deleting finalized item %s from the database",
 				event.Id,
 			)
@@ -330,7 +330,7 @@ func (li *BeefyEthereumListener) processFinalVerificationSuccessfulEvents(ctx co
 			continue
 		}
 
-		li.log.Info(
+		li.log.Infof(
 			"6: Deleting finalized item %s from the database",
 			event.Id,
 		)
@@ -380,8 +380,8 @@ func (li *BeefyEthereumListener) forwardReadyToCompleteItems(ctx context.Context
 				li.log.WithError(err).Error("Failure fetching inclusion block")
 			}
 
-			li.log.Info(
-				"4: Updating item %s status from 'InitialVerificationTxConfirmed' to 'ReadyToComplete'",
+			li.log.Infof(
+				"4: Updating item %v status from 'InitialVerificationTxConfirmed' to 'ReadyToComplete'",
 				item.ID,
 			)
 			item.Status = store.ReadyToComplete

--- a/relayer/workers/beefyrelayer/beefy-ethereum-listener.go
+++ b/relayer/workers/beefyrelayer/beefy-ethereum-listener.go
@@ -182,7 +182,10 @@ func (li *BeefyEthereumListener) processHistoricalInitialVerificationSuccessfulE
 			generatedPayload := li.simulatePayloadGeneration(*item)
 			if generatedPayload == validationData.CommitmentHash {
 				// Update existing database item
-				li.log.Info("Updating item status from 'CommitmentWitnessed' to 'InitialVerificationTxConfirmed' and adding ID")
+				li.log.Info(
+					"Updating item %s status from 'CommitmentWitnessed' to 'InitialVerificationTxConfirmed'",
+					event.Id,
+				)
 				instructions := map[string]interface{}{
 					"contract_id":             event.Id.Int64(),
 					"status":                  store.InitialVerificationTxConfirmed,
@@ -234,7 +237,10 @@ func (li *BeefyEthereumListener) processInitialVerificationSuccessfulEvents(ctx 
 			continue
 		}
 
-		li.log.Info("3: Updating status from 'InitialVerificationTxSent' to 'InitialVerificationTxConfirmed'")
+		li.log.Info(
+			"3: Updating item %s status from 'InitialVerificationTxSent' to 'InitialVerificationTxConfirmed'",
+			event.Id,
+		)
 		instructions := map[string]interface{}{
 			"contract_id":       event.Id.Int64(),
 			"status":            store.InitialVerificationTxConfirmed,
@@ -289,7 +295,10 @@ func (li *BeefyEthereumListener) processHistoricalFinalVerificationSuccessfulEve
 	for _, event := range events {
 		item := li.beefyDB.GetItemByID(event.Id.Int64())
 		if int64(item.ID) == event.Id.Int64() {
-			li.log.Info("Deleting finalized item from the database'")
+			li.log.Info(
+				"Deleting finalized item %s from the database",
+				event.Id,
+			)
 			deleteCmd := store.NewDatabaseCmd(item, store.Delete, nil)
 			li.dbMessages <- deleteCmd
 		} else {
@@ -321,7 +330,10 @@ func (li *BeefyEthereumListener) processFinalVerificationSuccessfulEvents(ctx co
 			continue
 		}
 
-		li.log.Info("6: Deleting finalized item from the database'")
+		li.log.Info(
+			"6: Deleting finalized item %s from the database",
+			event.Id,
+		)
 
 		item := li.beefyDB.GetItemByID(event.Id.Int64())
 		deleteCmd := store.NewDatabaseCmd(item, store.Delete, nil)
@@ -368,7 +380,10 @@ func (li *BeefyEthereumListener) forwardReadyToCompleteItems(ctx context.Context
 				li.log.WithError(err).Error("Failure fetching inclusion block")
 			}
 
-			li.log.Info("4: Updating item status from 'InitialVerificationTxConfirmed' to 'ReadyToComplete'")
+			li.log.Info(
+				"4: Updating item %s status from 'InitialVerificationTxConfirmed' to 'ReadyToComplete'",
+				item.ID,
+			)
 			item.Status = store.ReadyToComplete
 			item.RandomSeed = block.Hash()
 			li.beefyMessages <- *item

--- a/relayer/workers/beefyrelayer/beefy-ethereum-writer.go
+++ b/relayer/workers/beefyrelayer/beefy-ethereum-writer.go
@@ -144,7 +144,7 @@ func (wr *BeefyEthereumWriter) WriteCompleteSignatureCommitment(ctx context.Cont
 		return fmt.Errorf("Error converting BeefyRelayInfo to BeefyJustification: %s", err.Error())
 	}
 
-	msg, err := beefyJustification.BuildCompleteSignatureCommitmentMessage()
+	msg, err := beefyJustification.BuildCompleteSignatureCommitmentMessage(info)
 	if err != nil {
 		return err
 	}

--- a/relayer/workers/beefyrelayer/store/beefy.go
+++ b/relayer/workers/beefyrelayer/store/beefy.go
@@ -125,10 +125,10 @@ func (b *BeefyJustification) GenerateMerkleProofOffchain(valAddrIndex int) ([][3
 	return sigProofContents, nil
 }
 
-func (b *BeefyJustification) BuildCompleteSignatureCommitmentMessage() (CompleteSignatureCommitmentMessage, error) {
+func (b *BeefyJustification) BuildCompleteSignatureCommitmentMessage(info BeefyRelayInfo) (CompleteSignatureCommitmentMessage, error) {
 	commitmentHash := blake2b.Sum256(b.SignedCommitment.Commitment.Bytes())
 
-	validationDataID := big.NewInt(int64(b.SignedCommitment.Commitment.ValidatorSetID))
+	validationDataID := big.NewInt(int64(info.ContractID))
 
 	//TODO: Use info.RandomSeed.Big() to generate validatorPositions
 	validatorPositions := []*big.Int{}

--- a/relayer/workers/beefyrelayer/store/store.go
+++ b/relayer/workers/beefyrelayer/store/store.go
@@ -28,6 +28,7 @@ type BeefyRelayInfo struct {
 	gorm.Model
 	ValidatorAddresses         []byte
 	SignedCommitment           []byte
+	ContractID                 int64
 	Status                     Status
 	InitialVerificationTxHash  common.Hash
 	CompleteOnBlock            uint64
@@ -35,12 +36,13 @@ type BeefyRelayInfo struct {
 	CompleteVerificationTxHash common.Hash
 }
 
-func NewBeefyRelayInfo(validatorAddresses, signedCommitment []byte, status Status,
+func NewBeefyRelayInfo(validatorAddresses, signedCommitment []byte, contractId int64, status Status,
 	initialVerificationTxHash common.Hash, completeOnBlock uint64, randomSeed,
 	completeVerificationTxHash common.Hash) BeefyRelayInfo {
 	return BeefyRelayInfo{
 		ValidatorAddresses:         validatorAddresses,
 		SignedCommitment:           signedCommitment,
+		ContractID:                 contractId,
 		Status:                     status,
 		InitialVerificationTxHash:  initialVerificationTxHash,
 		CompleteOnBlock:            completeOnBlock,
@@ -194,14 +196,20 @@ func (d *Database) GetItemsByStatus(status Status) []*BeefyRelayInfo {
 	return items
 }
 
+func (d *Database) GetItemByID(id int64) *BeefyRelayInfo {
+	var item BeefyRelayInfo
+	d.DB.Take(&item, "contract_id = ?", id)
+	return &item
+}
+
 func (d *Database) GetItemByInitialVerificationTxHash(txHash common.Hash) *BeefyRelayInfo {
 	var item BeefyRelayInfo
 	d.DB.Take(&item, "initial_verification_tx_hash = ?", txHash)
 	return &item
 }
 
-func (d *Database) GetItemByFinalVerificationTxHash(txHash common.Hash) *BeefyRelayInfo {
+func (d *Database) GetItemByCompleteVerificationTxHash(txHash common.Hash) *BeefyRelayInfo {
 	var item BeefyRelayInfo
-	d.DB.Take(&item, "final_verification_tx_hash = ?", txHash)
+	d.DB.Take(&item, "complete_verification_tx_hash = ?", txHash)
 	return &item
 }

--- a/relayer/workers/beefyrelayer/store/store_test.go
+++ b/relayer/workers/beefyrelayer/store/store_test.go
@@ -11,14 +11,26 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/influxdata/influxdb/pkg/testing/assert"
 	"github.com/sirupsen/logrus"
 	"github.com/snowfork/go-substrate-rpc-client/v2/types"
 	"github.com/snowfork/polkadot-ethereum/relayer/workers/beefyrelayer/store"
+	"github.com/stretchr/testify/suite"
 	"golang.org/x/sync/errgroup"
 )
 
-func TestStore(t *testing.T) {
+type StoreTestSuite struct {
+	suite.Suite
+
+	database *store.Database
+	messages chan store.DatabaseCmd
+	ctx      context.Context
+}
+
+func TestStoreTestSuite(t *testing.T) {
+	suite.Run(t, new(StoreTestSuite))
+}
+
+func (suite *StoreTestSuite) SetupTest() {
 	config := store.Config{
 		Dialect: "sqlite3",
 		DBPath:  "tmp.db",
@@ -26,8 +38,7 @@ func TestStore(t *testing.T) {
 
 	db, err := store.PrepareDatabase(&config)
 	if err != nil {
-		t.Fatal(err)
-		t.Fail()
+		suite.Fail(err.Error())
 	}
 
 	messages := make(chan store.DatabaseCmd, 1)
@@ -51,23 +62,87 @@ func TestStore(t *testing.T) {
 		return nil
 	})
 
+	suite.messages = messages
+	suite.database = database
+	suite.ctx = ctx
+
 	// Start database update loop
 	err = database.Start(ctx, eg)
 	if err != nil {
 		panic(err)
 	}
+}
 
+func (suite *StoreTestSuite) TestGetItemsByStatus() {
 	item := loadSampleBeefyRelayInfo()
 
 	// Pass create command to write loop
 	createCmd := store.NewDatabaseCmd(&item, store.Create, nil)
-	messages <- createCmd
+	suite.messages <- createCmd
 
 	time.Sleep(2 * time.Second)
 
-	items := database.GetItemsByStatus(store.CommitmentWitnessed)
+	items := suite.database.GetItemsByStatus(store.CommitmentWitnessed)
 	beefyItem := items[0]
-	assert.Equal(t, beefyItem.Status, store.CommitmentWitnessed)
+	suite.Equal(beefyItem.Status, store.CommitmentWitnessed)
+}
+
+func (suite *StoreTestSuite) TestGetItemByID() {
+	id := int64(55)
+	item := loadSampleBeefyRelayInfo()
+	item.ContractID = id
+
+	// Pass create command to write loop
+	createCmd := store.NewDatabaseCmd(&item, store.Create, nil)
+	suite.messages <- createCmd
+
+	time.Sleep(2 * time.Second)
+
+	foundItem := suite.database.GetItemByID(id)
+	suite.Equal(item.ID, foundItem.ID)
+}
+
+func (suite *StoreTestSuite) TestGetItemByInitialVerificationTxHash() {
+	hash := common.BytesToHash([]byte("0x25451A4de12dcCc2D166922fA938E900fCc4ED24"))
+	item := loadSampleBeefyRelayInfo()
+	item.InitialVerificationTxHash = hash
+
+	// Pass create command to write loop
+	createCmd := store.NewDatabaseCmd(&item, store.Create, nil)
+	suite.messages <- createCmd
+
+	time.Sleep(2 * time.Second)
+
+	foundItem := suite.database.GetItemByInitialVerificationTxHash(hash)
+	suite.Equal(item.InitialVerificationTxHash, foundItem.InitialVerificationTxHash)
+}
+
+func (suite *StoreTestSuite) TestGetItemByCompleteVerificationTxHash() {
+	hash := common.BytesToHash([]byte("0x25451A4de12dcCc2D166922fA938E900fCc4ED24"))
+	item := loadSampleBeefyRelayInfo()
+	item.CompleteVerificationTxHash = hash
+
+	// Pass create command to write loop
+	createCmd := store.NewDatabaseCmd(&item, store.Create, nil)
+	suite.messages <- createCmd
+
+	time.Sleep(2 * time.Second)
+
+	foundItem := suite.database.GetItemByCompleteVerificationTxHash(hash)
+	suite.Equal(item.CompleteVerificationTxHash, foundItem.CompleteVerificationTxHash)
+}
+
+func (suite *StoreTestSuite) TestUpdateItem() {
+	item := loadSampleBeefyRelayInfo()
+
+	// Pass create command to write loop
+	createCmd := store.NewDatabaseCmd(&item, store.Create, nil)
+	suite.messages <- createCmd
+
+	time.Sleep(2 * time.Second)
+
+	items := suite.database.GetItemsByStatus(store.CommitmentWitnessed)
+	beefyItem := items[0]
 
 	// Pass update instruction to write loop
 	hash := common.BytesToHash([]byte("0x25451A4de12dcCc2D166922fA938E900fCc4ED24"))
@@ -76,22 +151,40 @@ func TestStore(t *testing.T) {
 		"InitialVerificationTxHash": hash,
 	}
 	updateCmd := store.NewDatabaseCmd(beefyItem, store.Update, instructions)
-	messages <- updateCmd
+	suite.messages <- updateCmd
 
 	time.Sleep(2 * time.Second)
 
-	newItem := database.GetItemByInitialVerificationTxHash(hash)
-	assert.Equal(t, newItem.Status, store.InitialVerificationTxSent)
-	assert.Equal(t, newItem.InitialVerificationTxHash, hash)
+	newItem := suite.database.GetItemByInitialVerificationTxHash(hash)
+	suite.Equal(newItem.Status, store.InitialVerificationTxSent)
+	suite.Equal(newItem.InitialVerificationTxHash, hash)
+}
+
+func (suite *StoreTestSuite) TestDeleteItem() {
+	id := int64(88)
+	item := loadSampleBeefyRelayInfo()
+	item.ContractID = id
+
+	// Pass create command to write loop
+	createCmd := store.NewDatabaseCmd(&item, store.Create, nil)
+	suite.messages <- createCmd
+
+	time.Sleep(2 * time.Second)
+
+	foundItem := suite.database.GetItemByID(id)
+	suite.Equal(item.ID, foundItem.ID)
+	suite.Equal(item.CompleteOnBlock, foundItem.CompleteOnBlock)
 
 	// Pass delete command to write loop
 	deleteCmd := store.NewDatabaseCmd(&item, store.Delete, nil)
-	messages <- deleteCmd
+	suite.messages <- deleteCmd
 
 	time.Sleep(2 * time.Second)
 
-	deletedItem := database.GetItemByInitialVerificationTxHash(hash)
-	assert.Equal(t, deletedItem, &store.BeefyRelayInfo{})
+	deletedItem := suite.database.GetItemByID(id)
+	suite.Equal(store.Status(0), deletedItem.Status)
+	suite.Equal(uint(0), deletedItem.ID)
+	suite.Equal(uint64(0), deletedItem.CompleteOnBlock)
 }
 
 func loadSampleBeefyRelayInfo() store.BeefyRelayInfo {
@@ -150,6 +243,7 @@ func loadSampleBeefyRelayInfo() store.BeefyRelayInfo {
 	return store.BeefyRelayInfo{
 		ValidatorAddresses:        valAddrBytes,
 		SignedCommitment:          signedCommitmentBytes,
+		ContractID:                int64(1),
 		Status:                    store.CommitmentWitnessed,
 		InitialVerificationTxHash: common.Hash{},
 		CompleteOnBlock:           22,


### PR DESCRIPTION
Refactored the relayer BEEFY store's test suite as part of this PR after finding a bug in the store's `GetItemByCompleteVerificationTxHash` method.