### PR TITLE
Update beefy relayer to send validator positions, signatures, pubkeys and pubkey merkle proofs correctly

### DIFF
--- a/ethereum/contracts/LightClientBridge.sol
+++ b/ethereum/contracts/LightClientBridge.sol
@@ -436,10 +436,7 @@ contract LightClientBridge {
     }
 
     function requiredNumberOfSignatures() public view returns (uint256) {
-        uint256 requiredNumOfSignaturesX100 =
-            (validatorRegistry.numOfValidators() * THRESHOLD_NUMERATOR * 100) /
+        return (validatorRegistry.numOfValidators() * THRESHOLD_NUMERATOR + THRESHOLD_DENOMINATOR - 1) /
                 THRESHOLD_DENOMINATOR;
-
-        return (requiredNumOfSignaturesX100 + 99) / 100;
     }
 }

--- a/ethereum/contracts/LightClientBridge.sol
+++ b/ethereum/contracts/LightClientBridge.sol
@@ -174,8 +174,7 @@ contract LightClientBridge {
          */
         require(
             validatorClaimsBitfield.countSetBits() >
-                (validatorRegistry.numOfValidators() * THRESHOLD_NUMERATOR) /
-                    THRESHOLD_DENOMINATOR,
+                requiredNumberOfSignatures(),
             "Error: Bitfield not enough validators"
         );
 
@@ -212,16 +211,8 @@ contract LightClientBridge {
             "Error: Block wait period not over"
         );
 
-        uint256 requiredNumOfSignatures =
-            (validatorRegistry.numOfValidators() * THRESHOLD_NUMERATOR) /
-                THRESHOLD_DENOMINATOR;
-
         return
-            Bitfield.randomNBitsFromPrior(
-                getSeed(data),
-                data.validatorClaimsBitfield,
-                requiredNumOfSignatures
-            );
+            Bitfield.randomNBits(getSeed(data), requiredNumberOfSignatures());
     }
 
     /**
@@ -261,9 +252,7 @@ contract LightClientBridge {
             "Error: Sender address does not match original validation data"
         );
 
-        uint256 requiredNumOfSignatures =
-            (validatorRegistry.numOfValidators() * THRESHOLD_NUMERATOR) /
-                THRESHOLD_DENOMINATOR;
+        uint256 requiredNumOfSignatures = requiredNumberOfSignatures();
 
         /**
          * @dev verify that required number of signatures, positions, public keys and merkle proofs are
@@ -290,7 +279,7 @@ contract LightClientBridge {
          * @dev Generate an array of numbers
          */
         uint256[] memory randomBitfield =
-            Bitfield.randomNBitsFromPrior(
+            Bitfield.randomNBitsWithPriorCheck(
                 getSeed(data),
                 data.validatorClaimsBitfield,
                 requiredNumOfSignatures
@@ -432,5 +421,13 @@ contract LightClientBridge {
         // get beefy_authority_set from newest leaf
         // update authority set
         // validatorRegistry.updateValidatorSet(beefy_authority_set)
+    }
+
+    function requiredNumberOfSignatures() public view returns (uint256) {
+        uint256 requiredNumOfSignaturesX100 =
+            (validatorRegistry.numOfValidators() * THRESHOLD_NUMERATOR * 100) /
+                THRESHOLD_DENOMINATOR;
+
+        return (requiredNumOfSignaturesX100 + 99) / 100;
     }
 }

--- a/ethereum/contracts/LightClientBridge.sol
+++ b/ethereum/contracts/LightClientBridge.sol
@@ -196,7 +196,7 @@ contract LightClientBridge {
         currentId = currentId.add(1);
     }
 
-    function validatorBitfield(uint256 id)
+    function createRandomBitfield(uint256 id)
         public
         view
         returns (uint256[] memory)
@@ -212,7 +212,19 @@ contract LightClientBridge {
         );
 
         return
-            Bitfield.randomNBits(getSeed(data), requiredNumberOfSignatures());
+            Bitfield.randomNBitsWithPriorCheck(
+                getSeed(data),
+                data.validatorClaimsBitfield,
+                requiredNumberOfSignatures()
+            );
+    }
+
+    function createInitialBitfield(uint256[] calldata bitsToSet, uint256 length)
+        public
+        view
+        returns (uint256[] memory)
+    {
+        return Bitfield.createBitfield(bitsToSet, length);
     }
 
     /**
@@ -221,7 +233,7 @@ contract LightClientBridge {
      * @param commitmentHash contains the commitmentHash signed by the validator(s)
      * @param commitment contains the full commitment that was used for the commitmentHash
      * @param signatures an array of signatures from the randomly chosen validators
-     * @param validatorPositions an array of bitfields from the chosen validators
+     * @param validatorPositions an array of the positions of the randomly chosen validators
      * @param validatorPublicKeys an array of the public key of each signer
      * @param validatorPublicKeyMerkleProofs an array of merkle proofs from the chosen validators
      */

--- a/ethereum/contracts/LightClientBridge.sol
+++ b/ethereum/contracts/LightClientBridge.sol
@@ -170,10 +170,10 @@ contract LightClientBridge {
         );
 
         /**
-         * @dev Check that the bitfield actually contains enough claims to be succesful, ie, > 2/3
+         * @dev Check that the bitfield actually contains enough claims to be succesful, ie, >= 2/3
          */
         require(
-            validatorClaimsBitfield.countSetBits() >
+            validatorClaimsBitfield.countSetBits() >=
                 requiredNumberOfSignatures(),
             "Error: Bitfield not enough validators"
         );

--- a/ethereum/contracts/utils/Bitfield.sol
+++ b/ethereum/contracts/utils/Bitfield.sol
@@ -79,7 +79,7 @@ library Bitfield {
         bitfield = new uint256[](arrayLength);
 
         for (uint256 i = 0; i < bitsToSet.length; i++) {
-            set(bitfield, i);
+            set(bitfield, bitsToSet[i]);
         }
 
         return bitfield;

--- a/ethereum/contracts/utils/Bitfield.sol
+++ b/ethereum/contracts/utils/Bitfield.sol
@@ -68,33 +68,18 @@ library Bitfield {
         return bitfield;
     }
 
-    /**
-     * @notice Draws a random number, derives an index in the bitfield, and sets the bit if it is in the `prior` and not
-     * yet set. Repeats that `n` times.
-     */
-    function randomNBits(uint256 seed, uint256 n)
+    function createBitfield(uint256[] calldata bitsToSet, uint256 length)
         public
         pure
         returns (uint256[] memory bitfield)
     {
         // Calculate length of uint256 array based on rounding up to number of uint256 needed
-        uint256 arrayLength = (n + 255) / 256;
+        uint256 arrayLength = (length + 255) / 256;
 
         bitfield = new uint256[](arrayLength);
-        uint256 found = 0;
 
-        for (uint256 i = 0; found < n; i++) {
-            bytes32 randomness = keccak256(abi.encode(seed + i));
-            uint256 index = uint256(randomness) % n;
-
-            // require a not yet set (new) bit to be set
-            if (isSet(bitfield, index)) {
-                continue;
-            }
-
-            set(bitfield, index);
-
-            found++;
+        for (uint256 i = 0; i < bitsToSet.length; i++) {
+            set(bitfield, i);
         }
 
         return bitfield;

--- a/ethereum/contracts/utils/Bitfield.sol
+++ b/ethereum/contracts/utils/Bitfield.sol
@@ -87,11 +87,6 @@ library Bitfield {
             bytes32 randomness = keccak256(abi.encode(seed + i));
             uint256 index = uint256(randomness) % n;
 
-            // require randomly seclected bit to be set in prior
-            if (!isSet(prior, index)) {
-                continue;
-            }
-
             // require a not yet set (new) bit to be set
             if (isSet(bitfield, index)) {
                 continue;

--- a/ethereum/contracts/utils/Bitfield.sol
+++ b/ethereum/contracts/utils/Bitfield.sol
@@ -38,8 +38,8 @@ library Bitfield {
         uint256 n
     ) public pure returns (uint256[] memory bitfield) {
         require(
-            n == countSetBits(prior),
-            "`n` must be == number of set bits in `prior`"
+            n <= countSetBits(prior),
+            "`n` must be <= number of set bits in `prior`"
         );
 
         bitfield = new uint256[](prior.length);

--- a/ethereum/contracts/utils/Bitfield.sol
+++ b/ethereum/contracts/utils/Bitfield.sol
@@ -32,14 +32,14 @@ library Bitfield {
      * @notice Draws a random number, derives an index in the bitfield, and sets the bit if it is in the `prior` and not
      * yet set. Repeats that `n` times.
      */
-    function randomNBitsFromPrior(
+    function randomNBitsWithPriorCheck(
         uint256 seed,
         uint256[] memory prior,
         uint256 n
     ) public pure returns (uint256[] memory bitfield) {
         require(
-            n <= countSetBits(prior),
-            "`n` must be <= number of set bits in `prior`"
+            n == countSetBits(prior),
+            "`n` must be == number of set bits in `prior`"
         );
 
         bitfield = new uint256[](prior.length);
@@ -55,7 +55,44 @@ library Bitfield {
                 continue;
             }
 
-            // require a not yet sit (new) bit to be set
+            // require a not yet set (new) bit to be set
+            if (isSet(bitfield, index)) {
+                continue;
+            }
+
+            set(bitfield, index);
+
+            found++;
+        }
+
+        return bitfield;
+    }
+
+    /**
+     * @notice Draws a random number, derives an index in the bitfield, and sets the bit if it is in the `prior` and not
+     * yet set. Repeats that `n` times.
+     */
+    function randomNBits(uint256 seed, uint256 n)
+        public
+        pure
+        returns (uint256[] memory bitfield)
+    {
+        // Calculate length of uint256 array based on rounding up to number of uint256 needed
+        uint256 arrayLength = (n + 255) / 256;
+
+        bitfield = new uint256[](arrayLength);
+        uint256 found = 0;
+
+        for (uint256 i = 0; found < n; i++) {
+            bytes32 randomness = keccak256(abi.encode(seed + i));
+            uint256 index = uint256(randomness) % n;
+
+            // require randomly seclected bit to be set in prior
+            if (!isSet(prior, index)) {
+                continue;
+            }
+
+            // require a not yet set (new) bit to be set
             if (isSet(bitfield, index)) {
                 continue;
             }

--- a/relayer/contracts/lightclientbridge/contract.go
+++ b/relayer/contracts/lightclientbridge/contract.go
@@ -34,7 +34,7 @@ type LightClientBridgeCommitment struct {
 }
 
 // ContractABI is the input ABI used to generate the binding from.
-const ContractABI = "[{\"inputs\":[{\"internalType\":\"contractValidatorRegistry\",\"name\":\"_validatorRegistry\",\"type\":\"address\"},{\"internalType\":\"contractMMRVerification\",\"name\":\"_mmrVerification\",\"type\":\"address\"},{\"internalType\":\"contractBlake2b\",\"name\":\"_blake2b\",\"type\":\"address\"}],\"stateMutability\":\"nonpayable\",\"type\":\"constructor\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"address\",\"name\":\"prover\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"bytes32\",\"name\":\"commitmentHash\",\"type\":\"bytes32\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"id\",\"type\":\"uint256\"}],\"name\":\"FinalVerificationSuccessful\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"address\",\"name\":\"prover\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"blockNumber\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"id\",\"type\":\"uint256\"}],\"name\":\"InitialVerificationSuccessful\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"bytes32\",\"name\":\"mmrRoot\",\"type\":\"bytes32\"},{\"indexed\":false,\"internalType\":\"uint64\",\"name\":\"blockNumber\",\"type\":\"uint64\"}],\"name\":\"NewMMRRoot\",\"type\":\"event\"},{\"inputs\":[],\"name\":\"BLOCK_WAIT_PERIOD\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\",\"constant\":true},{\"inputs\":[],\"name\":\"THRESHOLD_DENOMINATOR\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\",\"constant\":true},{\"inputs\":[],\"name\":\"THRESHOLD_NUMERATOR\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\",\"constant\":true},{\"inputs\":[],\"name\":\"blake2b\",\"outputs\":[{\"internalType\":\"contractBlake2b\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\",\"constant\":true},{\"inputs\":[],\"name\":\"currentId\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\",\"constant\":true},{\"inputs\":[],\"name\":\"latestMMRRoot\",\"outputs\":[{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"}],\"stateMutability\":\"view\",\"type\":\"function\",\"constant\":true},{\"inputs\":[],\"name\":\"mmrVerification\",\"outputs\":[{\"internalType\":\"contractMMRVerification\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\",\"constant\":true},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"name\":\"validationData\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"senderAddress\",\"type\":\"address\"},{\"internalType\":\"bytes32\",\"name\":\"commitmentHash\",\"type\":\"bytes32\"},{\"internalType\":\"uint256\",\"name\":\"blockNumber\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\",\"constant\":true},{\"inputs\":[],\"name\":\"validatorRegistry\",\"outputs\":[{\"internalType\":\"contractValidatorRegistry\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\",\"constant\":true},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"beefyMMRLeaf\",\"type\":\"bytes32\"},{\"internalType\":\"uint256\",\"name\":\"beefyMMRLeafIndex\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"beefyMMRLeafCount\",\"type\":\"uint256\"},{\"internalType\":\"bytes32[]\",\"name\":\"beefyMMRLeafProof\",\"type\":\"bytes32[]\"}],\"name\":\"verifyBeefyMerkleLeaf\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"commitmentHash\",\"type\":\"bytes32\"},{\"internalType\":\"uint256[]\",\"name\":\"validatorClaimsBitfield\",\"type\":\"uint256[]\"},{\"internalType\":\"bytes\",\"name\":\"validatorSignature\",\"type\":\"bytes\"},{\"internalType\":\"uint256\",\"name\":\"validatorPosition\",\"type\":\"uint256\"},{\"internalType\":\"address\",\"name\":\"validatorPublicKey\",\"type\":\"address\"},{\"internalType\":\"bytes32[]\",\"name\":\"validatorPublicKeyMerkleProof\",\"type\":\"bytes32[]\"}],\"name\":\"newSignatureCommitment\",\"outputs\":[],\"stateMutability\":\"payable\",\"type\":\"function\",\"payable\":true},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"id\",\"type\":\"uint256\"}],\"name\":\"validatorBitfield\",\"outputs\":[{\"internalType\":\"uint256[]\",\"name\":\"\",\"type\":\"uint256[]\"}],\"stateMutability\":\"view\",\"type\":\"function\",\"constant\":true},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"id\",\"type\":\"uint256\"},{\"internalType\":\"bytes32\",\"name\":\"commitmentHash\",\"type\":\"bytes32\"},{\"components\":[{\"internalType\":\"bytes32\",\"name\":\"payload\",\"type\":\"bytes32\"},{\"internalType\":\"uint64\",\"name\":\"blockNumber\",\"type\":\"uint64\"},{\"internalType\":\"uint32\",\"name\":\"validatorSetId\",\"type\":\"uint32\"}],\"internalType\":\"structLightClientBridge.Commitment\",\"name\":\"commitment\",\"type\":\"tuple\"},{\"internalType\":\"bytes[]\",\"name\":\"signatures\",\"type\":\"bytes[]\"},{\"internalType\":\"uint256[]\",\"name\":\"validatorPositions\",\"type\":\"uint256[]\"},{\"internalType\":\"address[]\",\"name\":\"validatorPublicKeys\",\"type\":\"address[]\"},{\"internalType\":\"bytes32[][]\",\"name\":\"validatorPublicKeyMerkleProofs\",\"type\":\"bytes32[][]\"}],\"name\":\"completeSignatureCommitment\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"requiredNumberOfSignatures\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\",\"constant\":true}]"
+const ContractABI = "[{\"inputs\":[{\"internalType\":\"contractValidatorRegistry\",\"name\":\"_validatorRegistry\",\"type\":\"address\"},{\"internalType\":\"contractMMRVerification\",\"name\":\"_mmrVerification\",\"type\":\"address\"},{\"internalType\":\"contractBlake2b\",\"name\":\"_blake2b\",\"type\":\"address\"}],\"stateMutability\":\"nonpayable\",\"type\":\"constructor\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"address\",\"name\":\"prover\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"bytes32\",\"name\":\"commitmentHash\",\"type\":\"bytes32\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"id\",\"type\":\"uint256\"}],\"name\":\"FinalVerificationSuccessful\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"address\",\"name\":\"prover\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"blockNumber\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"id\",\"type\":\"uint256\"}],\"name\":\"InitialVerificationSuccessful\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"bytes32\",\"name\":\"mmrRoot\",\"type\":\"bytes32\"},{\"indexed\":false,\"internalType\":\"uint64\",\"name\":\"blockNumber\",\"type\":\"uint64\"}],\"name\":\"NewMMRRoot\",\"type\":\"event\"},{\"inputs\":[],\"name\":\"BLOCK_WAIT_PERIOD\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\",\"constant\":true},{\"inputs\":[],\"name\":\"THRESHOLD_DENOMINATOR\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\",\"constant\":true},{\"inputs\":[],\"name\":\"THRESHOLD_NUMERATOR\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\",\"constant\":true},{\"inputs\":[],\"name\":\"blake2b\",\"outputs\":[{\"internalType\":\"contractBlake2b\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\",\"constant\":true},{\"inputs\":[],\"name\":\"currentId\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\",\"constant\":true},{\"inputs\":[],\"name\":\"latestMMRRoot\",\"outputs\":[{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"}],\"stateMutability\":\"view\",\"type\":\"function\",\"constant\":true},{\"inputs\":[],\"name\":\"mmrVerification\",\"outputs\":[{\"internalType\":\"contractMMRVerification\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\",\"constant\":true},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"name\":\"validationData\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"senderAddress\",\"type\":\"address\"},{\"internalType\":\"bytes32\",\"name\":\"commitmentHash\",\"type\":\"bytes32\"},{\"internalType\":\"uint256\",\"name\":\"blockNumber\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\",\"constant\":true},{\"inputs\":[],\"name\":\"validatorRegistry\",\"outputs\":[{\"internalType\":\"contractValidatorRegistry\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\",\"constant\":true},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"beefyMMRLeaf\",\"type\":\"bytes32\"},{\"internalType\":\"uint256\",\"name\":\"beefyMMRLeafIndex\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"beefyMMRLeafCount\",\"type\":\"uint256\"},{\"internalType\":\"bytes32[]\",\"name\":\"beefyMMRLeafProof\",\"type\":\"bytes32[]\"}],\"name\":\"verifyBeefyMerkleLeaf\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"commitmentHash\",\"type\":\"bytes32\"},{\"internalType\":\"uint256[]\",\"name\":\"validatorClaimsBitfield\",\"type\":\"uint256[]\"},{\"internalType\":\"bytes\",\"name\":\"validatorSignature\",\"type\":\"bytes\"},{\"internalType\":\"uint256\",\"name\":\"validatorPosition\",\"type\":\"uint256\"},{\"internalType\":\"address\",\"name\":\"validatorPublicKey\",\"type\":\"address\"},{\"internalType\":\"bytes32[]\",\"name\":\"validatorPublicKeyMerkleProof\",\"type\":\"bytes32[]\"}],\"name\":\"newSignatureCommitment\",\"outputs\":[],\"stateMutability\":\"payable\",\"type\":\"function\",\"payable\":true},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"id\",\"type\":\"uint256\"}],\"name\":\"createRandomBitfield\",\"outputs\":[{\"internalType\":\"uint256[]\",\"name\":\"\",\"type\":\"uint256[]\"}],\"stateMutability\":\"view\",\"type\":\"function\",\"constant\":true},{\"inputs\":[{\"internalType\":\"uint256[]\",\"name\":\"bitsToSet\",\"type\":\"uint256[]\"},{\"internalType\":\"uint256\",\"name\":\"length\",\"type\":\"uint256\"}],\"name\":\"createInitialBitfield\",\"outputs\":[{\"internalType\":\"uint256[]\",\"name\":\"\",\"type\":\"uint256[]\"}],\"stateMutability\":\"view\",\"type\":\"function\",\"constant\":true},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"id\",\"type\":\"uint256\"},{\"internalType\":\"bytes32\",\"name\":\"commitmentHash\",\"type\":\"bytes32\"},{\"components\":[{\"internalType\":\"bytes32\",\"name\":\"payload\",\"type\":\"bytes32\"},{\"internalType\":\"uint64\",\"name\":\"blockNumber\",\"type\":\"uint64\"},{\"internalType\":\"uint32\",\"name\":\"validatorSetId\",\"type\":\"uint32\"}],\"internalType\":\"structLightClientBridge.Commitment\",\"name\":\"commitment\",\"type\":\"tuple\"},{\"internalType\":\"bytes[]\",\"name\":\"signatures\",\"type\":\"bytes[]\"},{\"internalType\":\"uint256[]\",\"name\":\"validatorPositions\",\"type\":\"uint256[]\"},{\"internalType\":\"address[]\",\"name\":\"validatorPublicKeys\",\"type\":\"address[]\"},{\"internalType\":\"bytes32[][]\",\"name\":\"validatorPublicKeyMerkleProofs\",\"type\":\"bytes32[][]\"}],\"name\":\"completeSignatureCommitment\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"requiredNumberOfSignatures\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\",\"constant\":true}]"
 
 // Contract is an auto generated Go binding around an Ethereum contract.
 type Contract struct {
@@ -302,6 +302,68 @@ func (_Contract *ContractCallerSession) Blake2b() (common.Address, error) {
 	return _Contract.Contract.Blake2b(&_Contract.CallOpts)
 }
 
+// CreateInitialBitfield is a free data retrieval call binding the contract method 0x5da57fe9.
+//
+// Solidity: function createInitialBitfield(uint256[] bitsToSet, uint256 length) view returns(uint256[])
+func (_Contract *ContractCaller) CreateInitialBitfield(opts *bind.CallOpts, bitsToSet []*big.Int, length *big.Int) ([]*big.Int, error) {
+	var out []interface{}
+	err := _Contract.contract.Call(opts, &out, "createInitialBitfield", bitsToSet, length)
+
+	if err != nil {
+		return *new([]*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([]*big.Int)).(*[]*big.Int)
+
+	return out0, err
+
+}
+
+// CreateInitialBitfield is a free data retrieval call binding the contract method 0x5da57fe9.
+//
+// Solidity: function createInitialBitfield(uint256[] bitsToSet, uint256 length) view returns(uint256[])
+func (_Contract *ContractSession) CreateInitialBitfield(bitsToSet []*big.Int, length *big.Int) ([]*big.Int, error) {
+	return _Contract.Contract.CreateInitialBitfield(&_Contract.CallOpts, bitsToSet, length)
+}
+
+// CreateInitialBitfield is a free data retrieval call binding the contract method 0x5da57fe9.
+//
+// Solidity: function createInitialBitfield(uint256[] bitsToSet, uint256 length) view returns(uint256[])
+func (_Contract *ContractCallerSession) CreateInitialBitfield(bitsToSet []*big.Int, length *big.Int) ([]*big.Int, error) {
+	return _Contract.Contract.CreateInitialBitfield(&_Contract.CallOpts, bitsToSet, length)
+}
+
+// CreateRandomBitfield is a free data retrieval call binding the contract method 0x92848016.
+//
+// Solidity: function createRandomBitfield(uint256 id) view returns(uint256[])
+func (_Contract *ContractCaller) CreateRandomBitfield(opts *bind.CallOpts, id *big.Int) ([]*big.Int, error) {
+	var out []interface{}
+	err := _Contract.contract.Call(opts, &out, "createRandomBitfield", id)
+
+	if err != nil {
+		return *new([]*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([]*big.Int)).(*[]*big.Int)
+
+	return out0, err
+
+}
+
+// CreateRandomBitfield is a free data retrieval call binding the contract method 0x92848016.
+//
+// Solidity: function createRandomBitfield(uint256 id) view returns(uint256[])
+func (_Contract *ContractSession) CreateRandomBitfield(id *big.Int) ([]*big.Int, error) {
+	return _Contract.Contract.CreateRandomBitfield(&_Contract.CallOpts, id)
+}
+
+// CreateRandomBitfield is a free data retrieval call binding the contract method 0x92848016.
+//
+// Solidity: function createRandomBitfield(uint256 id) view returns(uint256[])
+func (_Contract *ContractCallerSession) CreateRandomBitfield(id *big.Int) ([]*big.Int, error) {
+	return _Contract.Contract.CreateRandomBitfield(&_Contract.CallOpts, id)
+}
+
 // CurrentId is a free data retrieval call binding the contract method 0xe00dd161.
 //
 // Solidity: function currentId() view returns(uint256)
@@ -471,37 +533,6 @@ func (_Contract *ContractCallerSession) ValidationData(arg0 *big.Int) (struct {
 	BlockNumber    *big.Int
 }, error) {
 	return _Contract.Contract.ValidationData(&_Contract.CallOpts, arg0)
-}
-
-// ValidatorBitfield is a free data retrieval call binding the contract method 0xec0d24c2.
-//
-// Solidity: function validatorBitfield(uint256 id) view returns(uint256[])
-func (_Contract *ContractCaller) ValidatorBitfield(opts *bind.CallOpts, id *big.Int) ([]*big.Int, error) {
-	var out []interface{}
-	err := _Contract.contract.Call(opts, &out, "validatorBitfield", id)
-
-	if err != nil {
-		return *new([]*big.Int), err
-	}
-
-	out0 := *abi.ConvertType(out[0], new([]*big.Int)).(*[]*big.Int)
-
-	return out0, err
-
-}
-
-// ValidatorBitfield is a free data retrieval call binding the contract method 0xec0d24c2.
-//
-// Solidity: function validatorBitfield(uint256 id) view returns(uint256[])
-func (_Contract *ContractSession) ValidatorBitfield(id *big.Int) ([]*big.Int, error) {
-	return _Contract.Contract.ValidatorBitfield(&_Contract.CallOpts, id)
-}
-
-// ValidatorBitfield is a free data retrieval call binding the contract method 0xec0d24c2.
-//
-// Solidity: function validatorBitfield(uint256 id) view returns(uint256[])
-func (_Contract *ContractCallerSession) ValidatorBitfield(id *big.Int) ([]*big.Int, error) {
-	return _Contract.Contract.ValidatorBitfield(&_Contract.CallOpts, id)
 }
 
 // ValidatorRegistry is a free data retrieval call binding the contract method 0xf376ebbb.

--- a/relayer/contracts/lightclientbridge/contract.go
+++ b/relayer/contracts/lightclientbridge/contract.go
@@ -34,7 +34,7 @@ type LightClientBridgeCommitment struct {
 }
 
 // ContractABI is the input ABI used to generate the binding from.
-const ContractABI = "[{\"inputs\":[{\"internalType\":\"contractValidatorRegistry\",\"name\":\"_validatorRegistry\",\"type\":\"address\"},{\"internalType\":\"contractMMRVerification\",\"name\":\"_mmrVerification\",\"type\":\"address\"},{\"internalType\":\"contractBlake2b\",\"name\":\"_blake2b\",\"type\":\"address\"}],\"stateMutability\":\"nonpayable\",\"type\":\"constructor\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"address\",\"name\":\"prover\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"bytes32\",\"name\":\"commitmentHash\",\"type\":\"bytes32\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"id\",\"type\":\"uint256\"}],\"name\":\"FinalVerificationSuccessful\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"address\",\"name\":\"prover\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"blockNumber\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"id\",\"type\":\"uint256\"}],\"name\":\"InitialVerificationSuccessful\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"bytes32\",\"name\":\"mmrRoot\",\"type\":\"bytes32\"},{\"indexed\":false,\"internalType\":\"uint64\",\"name\":\"blockNumber\",\"type\":\"uint64\"}],\"name\":\"NewMMRRoot\",\"type\":\"event\"},{\"inputs\":[],\"name\":\"BLOCK_WAIT_PERIOD\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\",\"constant\":true},{\"inputs\":[],\"name\":\"THRESHOLD_DENOMINATOR\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\",\"constant\":true},{\"inputs\":[],\"name\":\"THRESHOLD_NUMERATOR\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\",\"constant\":true},{\"inputs\":[],\"name\":\"blake2b\",\"outputs\":[{\"internalType\":\"contractBlake2b\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\",\"constant\":true},{\"inputs\":[],\"name\":\"currentId\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\",\"constant\":true},{\"inputs\":[],\"name\":\"latestMMRRoot\",\"outputs\":[{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"}],\"stateMutability\":\"view\",\"type\":\"function\",\"constant\":true},{\"inputs\":[],\"name\":\"mmrVerification\",\"outputs\":[{\"internalType\":\"contractMMRVerification\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\",\"constant\":true},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"name\":\"validationData\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"senderAddress\",\"type\":\"address\"},{\"internalType\":\"bytes32\",\"name\":\"commitmentHash\",\"type\":\"bytes32\"},{\"internalType\":\"uint256\",\"name\":\"blockNumber\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\",\"constant\":true},{\"inputs\":[],\"name\":\"validatorRegistry\",\"outputs\":[{\"internalType\":\"contractValidatorRegistry\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\",\"constant\":true},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"beefyMMRLeaf\",\"type\":\"bytes32\"},{\"internalType\":\"uint256\",\"name\":\"beefyMMRLeafIndex\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"beefyMMRLeafCount\",\"type\":\"uint256\"},{\"internalType\":\"bytes32[]\",\"name\":\"beefyMMRLeafProof\",\"type\":\"bytes32[]\"}],\"name\":\"verifyBeefyMerkleLeaf\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"commitmentHash\",\"type\":\"bytes32\"},{\"internalType\":\"uint256[]\",\"name\":\"validatorClaimsBitfield\",\"type\":\"uint256[]\"},{\"internalType\":\"bytes\",\"name\":\"validatorSignature\",\"type\":\"bytes\"},{\"internalType\":\"uint256\",\"name\":\"validatorPosition\",\"type\":\"uint256\"},{\"internalType\":\"address\",\"name\":\"validatorPublicKey\",\"type\":\"address\"},{\"internalType\":\"bytes32[]\",\"name\":\"validatorPublicKeyMerkleProof\",\"type\":\"bytes32[]\"}],\"name\":\"newSignatureCommitment\",\"outputs\":[],\"stateMutability\":\"payable\",\"type\":\"function\",\"payable\":true},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"id\",\"type\":\"uint256\"},{\"internalType\":\"bytes32\",\"name\":\"commitmentHash\",\"type\":\"bytes32\"},{\"components\":[{\"internalType\":\"bytes32\",\"name\":\"payload\",\"type\":\"bytes32\"},{\"internalType\":\"uint64\",\"name\":\"blockNumber\",\"type\":\"uint64\"},{\"internalType\":\"uint32\",\"name\":\"validatorSetId\",\"type\":\"uint32\"}],\"internalType\":\"structLightClientBridge.Commitment\",\"name\":\"commitment\",\"type\":\"tuple\"},{\"internalType\":\"bytes[]\",\"name\":\"signatures\",\"type\":\"bytes[]\"},{\"internalType\":\"uint256[]\",\"name\":\"validatorPositions\",\"type\":\"uint256[]\"},{\"internalType\":\"address[]\",\"name\":\"validatorPublicKeys\",\"type\":\"address[]\"},{\"internalType\":\"bytes32[][]\",\"name\":\"validatorPublicKeyMerkleProofs\",\"type\":\"bytes32[][]\"}],\"name\":\"completeSignatureCommitment\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"}]"
+const ContractABI = "[{\"inputs\":[{\"internalType\":\"contractValidatorRegistry\",\"name\":\"_validatorRegistry\",\"type\":\"address\"},{\"internalType\":\"contractMMRVerification\",\"name\":\"_mmrVerification\",\"type\":\"address\"},{\"internalType\":\"contractBlake2b\",\"name\":\"_blake2b\",\"type\":\"address\"}],\"stateMutability\":\"nonpayable\",\"type\":\"constructor\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"address\",\"name\":\"prover\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"bytes32\",\"name\":\"commitmentHash\",\"type\":\"bytes32\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"id\",\"type\":\"uint256\"}],\"name\":\"FinalVerificationSuccessful\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"address\",\"name\":\"prover\",\"type\":\"address\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"blockNumber\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"id\",\"type\":\"uint256\"}],\"name\":\"InitialVerificationSuccessful\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"bytes32\",\"name\":\"mmrRoot\",\"type\":\"bytes32\"},{\"indexed\":false,\"internalType\":\"uint64\",\"name\":\"blockNumber\",\"type\":\"uint64\"}],\"name\":\"NewMMRRoot\",\"type\":\"event\"},{\"inputs\":[],\"name\":\"BLOCK_WAIT_PERIOD\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\",\"constant\":true},{\"inputs\":[],\"name\":\"THRESHOLD_DENOMINATOR\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\",\"constant\":true},{\"inputs\":[],\"name\":\"THRESHOLD_NUMERATOR\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\",\"constant\":true},{\"inputs\":[],\"name\":\"blake2b\",\"outputs\":[{\"internalType\":\"contractBlake2b\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\",\"constant\":true},{\"inputs\":[],\"name\":\"currentId\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\",\"constant\":true},{\"inputs\":[],\"name\":\"latestMMRRoot\",\"outputs\":[{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"}],\"stateMutability\":\"view\",\"type\":\"function\",\"constant\":true},{\"inputs\":[],\"name\":\"mmrVerification\",\"outputs\":[{\"internalType\":\"contractMMRVerification\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\",\"constant\":true},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"name\":\"validationData\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"senderAddress\",\"type\":\"address\"},{\"internalType\":\"bytes32\",\"name\":\"commitmentHash\",\"type\":\"bytes32\"},{\"internalType\":\"uint256\",\"name\":\"blockNumber\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\",\"constant\":true},{\"inputs\":[],\"name\":\"validatorRegistry\",\"outputs\":[{\"internalType\":\"contractValidatorRegistry\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\",\"constant\":true},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"beefyMMRLeaf\",\"type\":\"bytes32\"},{\"internalType\":\"uint256\",\"name\":\"beefyMMRLeafIndex\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"beefyMMRLeafCount\",\"type\":\"uint256\"},{\"internalType\":\"bytes32[]\",\"name\":\"beefyMMRLeafProof\",\"type\":\"bytes32[]\"}],\"name\":\"verifyBeefyMerkleLeaf\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"commitmentHash\",\"type\":\"bytes32\"},{\"internalType\":\"uint256[]\",\"name\":\"validatorClaimsBitfield\",\"type\":\"uint256[]\"},{\"internalType\":\"bytes\",\"name\":\"validatorSignature\",\"type\":\"bytes\"},{\"internalType\":\"uint256\",\"name\":\"validatorPosition\",\"type\":\"uint256\"},{\"internalType\":\"address\",\"name\":\"validatorPublicKey\",\"type\":\"address\"},{\"internalType\":\"bytes32[]\",\"name\":\"validatorPublicKeyMerkleProof\",\"type\":\"bytes32[]\"}],\"name\":\"newSignatureCommitment\",\"outputs\":[],\"stateMutability\":\"payable\",\"type\":\"function\",\"payable\":true},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"id\",\"type\":\"uint256\"}],\"name\":\"validatorBitfield\",\"outputs\":[{\"internalType\":\"uint256[]\",\"name\":\"\",\"type\":\"uint256[]\"}],\"stateMutability\":\"view\",\"type\":\"function\",\"constant\":true},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"id\",\"type\":\"uint256\"},{\"internalType\":\"bytes32\",\"name\":\"commitmentHash\",\"type\":\"bytes32\"},{\"components\":[{\"internalType\":\"bytes32\",\"name\":\"payload\",\"type\":\"bytes32\"},{\"internalType\":\"uint64\",\"name\":\"blockNumber\",\"type\":\"uint64\"},{\"internalType\":\"uint32\",\"name\":\"validatorSetId\",\"type\":\"uint32\"}],\"internalType\":\"structLightClientBridge.Commitment\",\"name\":\"commitment\",\"type\":\"tuple\"},{\"internalType\":\"bytes[]\",\"name\":\"signatures\",\"type\":\"bytes[]\"},{\"internalType\":\"uint256[]\",\"name\":\"validatorPositions\",\"type\":\"uint256[]\"},{\"internalType\":\"address[]\",\"name\":\"validatorPublicKeys\",\"type\":\"address[]\"},{\"internalType\":\"bytes32[][]\",\"name\":\"validatorPublicKeyMerkleProofs\",\"type\":\"bytes32[][]\"}],\"name\":\"completeSignatureCommitment\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"requiredNumberOfSignatures\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\",\"constant\":true}]"
 
 // Contract is an auto generated Go binding around an Ethereum contract.
 type Contract struct {
@@ -395,6 +395,37 @@ func (_Contract *ContractCallerSession) MmrVerification() (common.Address, error
 	return _Contract.Contract.MmrVerification(&_Contract.CallOpts)
 }
 
+// RequiredNumberOfSignatures is a free data retrieval call binding the contract method 0x72fe1a9f.
+//
+// Solidity: function requiredNumberOfSignatures() view returns(uint256)
+func (_Contract *ContractCaller) RequiredNumberOfSignatures(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _Contract.contract.Call(opts, &out, "requiredNumberOfSignatures")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// RequiredNumberOfSignatures is a free data retrieval call binding the contract method 0x72fe1a9f.
+//
+// Solidity: function requiredNumberOfSignatures() view returns(uint256)
+func (_Contract *ContractSession) RequiredNumberOfSignatures() (*big.Int, error) {
+	return _Contract.Contract.RequiredNumberOfSignatures(&_Contract.CallOpts)
+}
+
+// RequiredNumberOfSignatures is a free data retrieval call binding the contract method 0x72fe1a9f.
+//
+// Solidity: function requiredNumberOfSignatures() view returns(uint256)
+func (_Contract *ContractCallerSession) RequiredNumberOfSignatures() (*big.Int, error) {
+	return _Contract.Contract.RequiredNumberOfSignatures(&_Contract.CallOpts)
+}
+
 // ValidationData is a free data retrieval call binding the contract method 0x20bfa5cb.
 //
 // Solidity: function validationData(uint256 ) view returns(address senderAddress, bytes32 commitmentHash, uint256 blockNumber)
@@ -440,6 +471,37 @@ func (_Contract *ContractCallerSession) ValidationData(arg0 *big.Int) (struct {
 	BlockNumber    *big.Int
 }, error) {
 	return _Contract.Contract.ValidationData(&_Contract.CallOpts, arg0)
+}
+
+// ValidatorBitfield is a free data retrieval call binding the contract method 0xec0d24c2.
+//
+// Solidity: function validatorBitfield(uint256 id) view returns(uint256[])
+func (_Contract *ContractCaller) ValidatorBitfield(opts *bind.CallOpts, id *big.Int) ([]*big.Int, error) {
+	var out []interface{}
+	err := _Contract.contract.Call(opts, &out, "validatorBitfield", id)
+
+	if err != nil {
+		return *new([]*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([]*big.Int)).(*[]*big.Int)
+
+	return out0, err
+
+}
+
+// ValidatorBitfield is a free data retrieval call binding the contract method 0xec0d24c2.
+//
+// Solidity: function validatorBitfield(uint256 id) view returns(uint256[])
+func (_Contract *ContractSession) ValidatorBitfield(id *big.Int) ([]*big.Int, error) {
+	return _Contract.Contract.ValidatorBitfield(&_Contract.CallOpts, id)
+}
+
+// ValidatorBitfield is a free data retrieval call binding the contract method 0xec0d24c2.
+//
+// Solidity: function validatorBitfield(uint256 id) view returns(uint256[])
+func (_Contract *ContractCallerSession) ValidatorBitfield(id *big.Int) ([]*big.Int, error) {
+	return _Contract.Contract.ValidatorBitfield(&_Contract.CallOpts, id)
 }
 
 // ValidatorRegistry is a free data retrieval call binding the contract method 0xf376ebbb.

--- a/relayer/workers/beefyrelayer/beefy-ethereum-listener.go
+++ b/relayer/workers/beefyrelayer/beefy-ethereum-listener.go
@@ -348,7 +348,7 @@ func (li *BeefyEthereumListener) simulatePayloadGeneration(item store.BeefyRelay
 		li.log.WithError(fmt.Errorf("Error converting BeefyRelayInfo to BeefyJustification: %s", err.Error()))
 	}
 
-	msg, err := beefyJustification.BuildNewSignatureCommitmentMessage(0)
+	msg, err := beefyJustification.BuildNewSignatureCommitmentMessage(0, []*big.Int{})
 	if err != nil {
 		li.log.WithError(err).Error("Error building commitment message")
 	}

--- a/relayer/workers/beefyrelayer/beefy-ethereum-writer.go
+++ b/relayer/workers/beefyrelayer/beefy-ethereum-writer.go
@@ -107,10 +107,11 @@ func (wr *BeefyEthereumWriter) WriteNewSignatureCommitment(ctx context.Context, 
 	}
 
 	signedValidators := []*big.Int{}
-	for i, signature := range beefyJustification.SignedCommitment.Signatures {
-		if signature.Option.IsSome() {
-			signedValidators = append(signedValidators, big.NewInt(int64(i)))
-		}
+	for i := range beefyJustification.SignedCommitment.Signatures {
+		// TODO: skip over empty/missing signatures
+		// if signature.Option.IsSome() {
+		signedValidators = append(signedValidators, big.NewInt(int64(i)))
+		// }
 	}
 	numberOfValidators := big.NewInt(int64(len(beefyJustification.SignedCommitment.Signatures)))
 	initialBitfield, err := contract.CreateInitialBitfield(

--- a/relayer/workers/beefyrelayer/beefy-relaychain-listener.go
+++ b/relayer/workers/beefyrelayer/beefy-relaychain-listener.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/sirupsen/logrus"
 	"github.com/snowfork/go-substrate-rpc-client/v2/types"
 	"golang.org/x/sync/errgroup"
@@ -82,15 +83,10 @@ func (li *BeefyRelaychainListener) subBeefyJustifications(ctx context.Context) e
 				continue
 			}
 
-			// TODO:
-			// beefyAuthorities, err := li.getBeefyAuthorities(uint64(signedCommitment.Commitment.BlockNumber))
-			// if err != nil {
-			// 	li.log.WithError(err).Error("Failed to get Beefy authorities from on-chain storage")
-			// }
-
-			beefyAuthorities := []common.Address{
-				common.HexToAddress("0xE04CC55ebEE1cBCE552f250e85c57B70B2E2625b"),
-				common.HexToAddress("0x25451A4de12dcCc2D166922fA938E900fCc4ED24"),
+			beefyAuthorities, err := li.getBeefyAuthorities(uint64(signedCommitment.Commitment.BlockNumber))
+			if err != nil {
+				li.log.WithError(err).Error("Failed to get Beefy authorities from on-chain storage")
+				return err
 			}
 
 			beefyAuthoritiesBytes, err := json.Marshal(beefyAuthorities)
@@ -109,53 +105,52 @@ func (li *BeefyRelaychainListener) subBeefyJustifications(ctx context.Context) e
 	}
 }
 
-func (li *BeefyRelaychainListener) getBeefyAuthorities(blockNumber uint64) (substrate.Authorities, error) {
+func (li *BeefyRelaychainListener) getBeefyAuthorities(blockNumber uint64) ([]common.Address, error) {
 	blockHash, err := li.relaychainConn.GetAPI().RPC.Chain.GetBlockHash(blockNumber)
 	if err != nil {
-		return substrate.Authorities{}, err
+		return nil, err
 	}
 
 	meta, err := li.relaychainConn.GetAPI().RPC.State.GetMetadataLatest()
 	if err != nil {
-		return substrate.Authorities{}, err
+		return nil, err
 	}
 
 	storageKey, err := types.CreateStorageKey(meta, "Beefy", "Authorities", nil, nil)
 	if err != nil {
-		return substrate.Authorities{}, err
+		return nil, err
 	}
 
 	storageChangeSet, err := li.relaychainConn.GetAPI().RPC.State.QueryStorage([]types.StorageKey{storageKey}, blockHash, blockHash)
 	if err != nil {
-		return substrate.Authorities{}, err
+		return nil, err
 	}
 
 	authorities := substrate.Authorities{}
 	for _, storageChange := range storageChangeSet {
 		for _, keyValueOption := range storageChange.Changes {
-			bz, err := keyValueOption.MarshalJSON()
-			if err != nil {
-				return substrate.Authorities{}, err
-			}
 
-			err = types.DecodeFromBytes(bz, &authorities)
+			err = types.DecodeFromHexString(keyValueOption.StorageData.Hex(), &authorities)
 			if err != nil {
-				return substrate.Authorities{}, err
+				return nil, err
 			}
 
 		}
 	}
-	// TODO: Decode authorities using @polkadot/util-crypto/ethereum/encode.js ethereumEncode() method
 
-	// if data != nil {
-	// 	li.log.WithFields(logrus.Fields{
-	// 		"block":               signedCommitment.Commitment.BlockNumber,
-	// 		"commitmentSizeBytes": len(*data),
-	// 	}).Debug("Retrieved authorities from storage")
-	// } else {
-	// 	li.log.WithError(err).Error("Authorities not found in storage")
-	// 	continue
-	// }
+	// Convert from beefy authorities to ethereum addresses
+	var authorityEthereumAddresses []common.Address
+	for _, authority := range authorities {
+		pub, err := crypto.DecompressPubkey(authority[:])
+		if err != nil {
+			return nil, err
+		}
+		ethereumAddress := crypto.PubkeyToAddress(*pub)
+		if err != nil {
+			return nil, err
+		}
+		authorityEthereumAddresses = append(authorityEthereumAddresses, ethereumAddress)
+	}
 
-	return authorities, nil
+	return authorityEthereumAddresses, nil
 }

--- a/relayer/workers/beefyrelayer/store/beefy.go
+++ b/relayer/workers/beefyrelayer/store/beefy.go
@@ -130,11 +130,15 @@ func (b *BeefyJustification) BuildCompleteSignatureCommitmentMessage(info BeefyR
 
 	validationDataID := big.NewInt(int64(info.ContractID))
 
+	//TODO: Populate validatorPublicKeys, and based on validatorPositions
 	//TODO: Use info.RandomSeed.Big() to generate validatorPositions
 	validatorPositions := []*big.Int{}
 
-	//TODO: Populate signatures, validatorPublicKeys, and based on validatorPositions
 	signatures := [][]byte{}
+	for _, sig := range b.SignedCommitment.Signatures {
+		signatures = append(signatures, sig.Value[:])
+	}
+
 	validatorPublicKeys := b.ValidatorAddresses
 	validatorPublicKeyMerkleProofs := [][][32]byte{}
 
@@ -144,6 +148,7 @@ func (b *BeefyJustification) BuildCompleteSignatureCommitmentMessage(info BeefyR
 		ValidatorSetId: uint32(b.SignedCommitment.Commitment.ValidatorSetID),
 	}
 
+	fmt.Println("beefy-relayer sigs, ", signatures)
 	msg := CompleteSignatureCommitmentMessage{
 		ID:                             validationDataID,
 		CommitmentHash:                 commitmentHash,


### PR DESCRIPTION
Ready for review. The beefy-relayer is working now and completing the full initial+complete flow with all proofs/checks passing 🎉 🎉 🎉 

Some changes to smart contracts for review - plz review and audit these properly:
 - requiredNumberOfSignatures now moved to its own function and made to round up the calculation (eg: 2 validators with 2/3 now rounds up to 2 sigs required instead of 1)
 - createRandomBitfield added to smart contracts to generate a brand new bitfield with length based on rounding up to the nearest 256
 - validatorClaimsBitfield.countSetBits is now >= 2/3, rather than > 2/3 because the requiredNumberOfSignatures is rounded up. seems fine?